### PR TITLE
TUSC-316 Add Cloud Accounts Link to Gold Images Page

### DIFF
--- a/src/Components/GoldImages/GoldImagesTable.tsx
+++ b/src/Components/GoldImages/GoldImagesTable.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect } from 'react';
-import { GoldImagesResponse } from '../../hooks/api/useGoldImages';
+import {
+  CloudProviderName,
+  GoldImagesResponse,
+} from '../../hooks/api/useGoldImages';
 import {
   SortByDirection,
   Table,
@@ -24,6 +27,7 @@ import { hasPaginationError } from '../../utils/errors';
 import { PaginationError } from '../shared/PaginationError';
 import { Link } from 'react-router-dom';
 import { Paths } from '../../utils/routing';
+import { CloudProviderShortname } from '../../types/cloudAccountsTypes';
 
 interface GoldImagesProps {
   goldImages: GoldImagesResponse;
@@ -61,6 +65,12 @@ export const GoldImagesTable = ({ goldImages }: GoldImagesProps) => {
     (pageOptions.page - 1) * pageOptions.perPage,
     pageOptions.page * pageOptions.perPage,
   );
+
+  const goldImagesProviderToCloudAccountShortName = {
+    [CloudProviderName.AWS]: CloudProviderShortname.AWS,
+    [CloudProviderName.GCP]: CloudProviderShortname.GCP,
+    [CloudProviderName.AZURE]: CloudProviderShortname.AZURE,
+  };
 
   useEffect(() => {
     setGoldImagePagination({
@@ -101,9 +111,16 @@ export const GoldImagesTable = ({ goldImages }: GoldImagesProps) => {
               </Td>
               <Td modifier="fitContent">
                 <Link
-                  to={`../${Paths.CloudAccounts}?${generateQueryParamsForData([hyperscaler.provider], 'shortName').toString()}`}
+                  to={`../${Paths.CloudAccounts}?${generateQueryParamsForData(
+                    [
+                      goldImagesProviderToCloudAccountShortName[
+                        hyperscaler.provider
+                      ],
+                    ],
+                    'shortName',
+                  ).toString()}`}
                 >
-                  View cloud accounts
+                    View cloud accounts
                 </Link>
               </Td>
             </Tr>

--- a/src/Components/GoldImages/GoldImagesTable.tsx
+++ b/src/Components/GoldImages/GoldImagesTable.tsx
@@ -16,9 +16,14 @@ import {
   cloudProviderFilterData,
   goldImagePaginationData,
 } from '../../state/goldImages';
-import { useQueryParamInformedAtom } from '../../hooks/util/useQueryParam';
+import {
+  generateQueryParamsForData,
+  useQueryParamInformedAtom,
+} from '../../hooks/util/useQueryParam';
 import { hasPaginationError } from '../../utils/errors';
 import { PaginationError } from '../shared/PaginationError';
+import { Link } from 'react-router-dom';
+import { Paths } from '../../utils/routing';
 
 interface GoldImagesProps {
   goldImages: GoldImagesResponse;
@@ -93,6 +98,13 @@ export const GoldImagesTable = ({ goldImages }: GoldImagesProps) => {
                     </Content>
                   );
                 })}
+              </Td>
+              <Td modifier="fitContent">
+                <Link
+                  to={`../${Paths.CloudAccounts}?${generateQueryParamsForData([hyperscaler.provider], 'shortName').toString()}`}
+                >
+                  View cloud accounts
+                </Link>
               </Td>
             </Tr>
           );

--- a/src/Components/GoldImages/__tests__/GoldImagesTable.test.tsx
+++ b/src/Components/GoldImages/__tests__/GoldImagesTable.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithRouter } from '../../../utils/testing/customRender';
 import {
   CloudProviderName,
@@ -153,5 +153,23 @@ describe('Gold images table', () => {
 
     expect(container.querySelector('thead')).not.toBeInTheDocument();
     expect(container.querySelector('tbody')).not.toBeInTheDocument();
+  });
+  it('renders cloud accounts links for each provider', () => {
+    renderWithRouter(<GoldImagesTable goldImages={goldImageTestData(3)} />);
+
+    const links = screen.getAllByRole('link', {
+      name: /view cloud accounts/i,
+    });
+
+    expect(links).toHaveLength(3);
+    expect(links[0]).toHaveAttribute(
+      'href',
+      expect.stringContaining('cloud-accounts'),
+    );
+    expect(links[0]).toHaveAttribute(
+      'href',
+      expect.stringContaining('shortName'),
+    );
+    expect(links[0]).toHaveAttribute('href', expect.stringContaining('AWS'));
   });
 });

--- a/src/Components/GoldImages/__tests__/GoldImagesTable.test.tsx
+++ b/src/Components/GoldImages/__tests__/GoldImagesTable.test.tsx
@@ -11,6 +11,7 @@ import {
   cloudProviderFilterData,
   goldImagePaginationData,
 } from '../../../state/goldImages';
+import { Paths } from '../../../utils/routing';
 
 const goldImageTestData: (amount: number) => GoldImagesResponse = (
   amount: number,
@@ -164,7 +165,7 @@ describe('Gold images table', () => {
     expect(links).toHaveLength(3);
     expect(links[0]).toHaveAttribute(
       'href',
-      expect.stringContaining('cloud-accounts'),
+      expect.stringContaining(Paths.CloudAccounts),
     );
     expect(links[0]).toHaveAttribute(
       'href',

--- a/src/Pages/GoldImagesPage/GoldImagesPage.tsx
+++ b/src/Pages/GoldImagesPage/GoldImagesPage.tsx
@@ -6,7 +6,7 @@ import { Unavailable } from '@redhat-cloud-services/frontend-components/Unavaila
 import { PageHeader } from '@redhat-cloud-services/frontend-components/PageHeader';
 import { GoldImagesTable } from '../../Components/GoldImages/GoldImagesTable';
 import { useRbacPermission } from '../../hooks/util/useRbacPermissions';
-import { Navigate } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
 import { Paths } from '../../utils/routing';
 import { GoldImagesToolbar } from '../../Components/GoldImages/GoldImagesToolbar';
 import { GoldImagesPagination } from '../../Components/GoldImages/GoldImagesPagination';
@@ -37,7 +37,9 @@ export const GoldImagesPage = () => {
         <Content component="h1">Gold Images</Content>
         <Content component="p">
           This is a listing of the gold images available to your organization,
-          based on your subscriptions. Learn more about gold images.
+          based on your subscriptions. Learn more about gold images. To see
+          which cloud accounts have gold image access enabled, view the list of
+          your <Link to={`../${Paths.CloudAccounts}`}>cloud accounts.</Link>
         </Content>
       </PageHeader>
       <Section>


### PR DESCRIPTION
add cloud accounts link to Gold Images page description add View cloud accounts action column to Gold Images table link each provider row to filtered Cloud Accounts view using shortName query params add tests covering cloud accounts link rendering

## Summary by Sourcery

Add navigation from Gold Images to Cloud Accounts for providers with gold image access.

New Features:
- Add a 'View cloud accounts' link in each Gold Images table row that navigates to the Cloud Accounts page filtered by the provider short name.
- Add a contextual link in the Gold Images page description to the Cloud Accounts list.

Tests:
- Add tests verifying that a cloud accounts link is rendered for each provider row with the expected URL parameters.