### PR TITLE
TUSC-551: Remove unused packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,14 +24,13 @@
       "devDependencies": {
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^3.0.0",
         "@redhat-cloud-services/frontend-components-config": "^6.5.4",
-        "@redhat-cloud-services/tsc-transform-imports": "^1.0.16",
+        "@redhat-cloud-services/tsc-transform-imports": "^1.2.1",
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.3.0",
         "@types/jest": "^29.5.13",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
         "@types/react-router-dom": "^5.3.3",
-        "@types/redux-logger": "^3.0.13",
         "@typescript-eslint/eslint-plugin": "^8.53.0",
         "@typescript-eslint/parser": "^8.53.0",
         "eslint": "^9.24.0",
@@ -44,8 +43,7 @@
         "rimraf": "^5.0.10",
         "ts-jest": "^29.2.5",
         "ts-patch": "^3.2.1",
-        "typescript": "^5.6.2",
-        "webpack-bundle-analyzer": "4.10.2"
+        "typescript": "^5.6.2"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -3747,13 +3745,6 @@
         }
       }
     },
-    "node_modules/@polka/url": {
-      "version": "1.0.0-next.29",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
-      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@redhat-cloud-services/eslint-config-redhat-cloud-services": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@redhat-cloud-services/eslint-config-redhat-cloud-services/-/eslint-config-redhat-cloud-services-3.1.2.tgz",
@@ -3944,9 +3935,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/tsc-transform-imports": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/tsc-transform-imports/-/tsc-transform-imports-1.1.2.tgz",
-      "integrity": "sha512-age6chkrO7bZlYS6w0FGvUJxSG4FP4LI2Z5BVob/POSaiJHMIHmFxKykTRf2Vcy8EJwyBRLzGls8cwTrIby8aA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/tsc-transform-imports/-/tsc-transform-imports-1.2.1.tgz",
+      "integrity": "sha512-XcMWPfABA5UqCGMg81xmJSp5pMaH8Fk5hwA2bzrBvNTzJimXpFwEgTZS5ZTLod6MCLcmTSfA5wRcXDCQqjdESw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5250,16 +5241,6 @@
         "@types/react-router": "*"
       }
     },
-    "node_modules/@types/redux-logger": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.13.tgz",
-      "integrity": "sha512-jylqZXQfMxahkuPcO8J12AKSSCQngdEWQrw7UiLUJzMBcv1r4Qg77P6mjGLjM27e5gFQDPD8vwUMJ9AyVxFSsg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "redux": "^5.0.0"
-      }
-    },
     "node_modules/@types/retry": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
@@ -6265,19 +6246,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
-      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -8203,13 +8171,6 @@
       "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "license": "MIT"
     },
-    "node_modules/debounce": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
-      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/debounce-promise": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/debounce-promise/-/debounce-promise-3.1.2.tgz",
@@ -8635,13 +8596,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -10451,22 +10405,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/gzip-size": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
-      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "^0.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -10717,7 +10655,8 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/html-minifier-terser": {
       "version": "6.1.0",
@@ -15035,16 +14974,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mrmime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
-      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -16710,13 +16639,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -17710,21 +17632,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/sirv": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
-      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@polka/url": "^1.0.0-next.24",
-        "mrmime": "^2.0.0",
-        "totalist": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -18637,16 +18544,6 @@
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
       "license": "MIT"
     },
-    "node_modules/totalist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
-      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -19520,65 +19417,6 @@
       },
       "peerDependenciesMeta": {
         "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-bundle-analyzer": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.2.tgz",
-      "integrity": "sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@discoveryjs/json-ext": "0.5.7",
-        "acorn": "^8.0.4",
-        "acorn-walk": "^8.0.0",
-        "commander": "^7.2.0",
-        "debounce": "^1.2.1",
-        "escape-string-regexp": "^4.0.0",
-        "gzip-size": "^6.0.0",
-        "html-escaper": "^2.0.2",
-        "opener": "^1.5.2",
-        "picocolors": "^1.0.0",
-        "sirv": "^2.0.3",
-        "ws": "^7.3.1"
-      },
-      "bin": {
-        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -40,14 +40,13 @@
   "devDependencies": {
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^3.0.0",
     "@redhat-cloud-services/frontend-components-config": "^6.5.4",
-    "@redhat-cloud-services/tsc-transform-imports": "^1.0.16",
+    "@redhat-cloud-services/tsc-transform-imports": "^1.2.1",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^29.5.13",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
     "@types/react-router-dom": "^5.3.3",
-    "@types/redux-logger": "^3.0.13",
     "@typescript-eslint/eslint-plugin": "^8.53.0",
     "@typescript-eslint/parser": "^8.53.0",
     "eslint": "^9.24.0",
@@ -60,8 +59,7 @@
     "rimraf": "^5.0.10",
     "ts-jest": "^29.2.5",
     "ts-patch": "^3.2.1",
-    "typescript": "^5.6.2",
-    "webpack-bundle-analyzer": "4.10.2"
+    "typescript": "^5.6.2"
   },
   "insights": {
     "appname": "cloud-inventory"

--- a/src/Components/util/testing/ManipulatableQueryWrapper.tsx
+++ b/src/Components/util/testing/ManipulatableQueryWrapper.tsx
@@ -5,6 +5,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: false,
+      staleTime: Infinity,
     },
   },
 });

--- a/src/Components/util/testing/ManipulatableQueryWrapper.tsx
+++ b/src/Components/util/testing/ManipulatableQueryWrapper.tsx
@@ -1,7 +1,13 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
 
 export const ManipulatableQueryWrapper = (children: JSX.Element) => ({
   ComponentWithQueryClient: () => (

--- a/src/Pages/CloudAccountsPage/__tests__/CloudAccountsPage.test.tsx
+++ b/src/Pages/CloudAccountsPage/__tests__/CloudAccountsPage.test.tsx
@@ -59,9 +59,9 @@ it('renders cloud accounts page', async () => {
     },
   });
 
-  renderWithRouter(<ComponentWithQueryClient />);
+  const { findByText } = renderWithRouter(<ComponentWithQueryClient />);
 
-  expect(await screen.findByText('Cloud Accounts')).toBeInTheDocument();
+  expect(await findByText('Cloud Accounts')).toBeInTheDocument();
 });
 
 it('shows empty state when no accounts exist', async () => {

--- a/src/Pages/CloudAccountsPage/__tests__/CloudAccountsPage.test.tsx
+++ b/src/Pages/CloudAccountsPage/__tests__/CloudAccountsPage.test.tsx
@@ -59,9 +59,9 @@ it('renders cloud accounts page', async () => {
     },
   });
 
-  const { findByText } = renderWithRouter(<ComponentWithQueryClient />);
+  renderWithRouter(<ComponentWithQueryClient />);
 
-  expect(await findByText('Cloud Accounts')).toBeInTheDocument();
+  expect(await screen.findByText('Cloud Accounts')).toBeInTheDocument();
 });
 
 it('shows empty state when no accounts exist', async () => {


### PR DESCRIPTION
This is a newer app, so there aren't nearly as many unused packages. However, this removes the ones that are

## Summary by Sourcery

Remove unused frontend dev dependencies and update remaining tooling to the latest compatible version.

Build:
- Update @redhat-cloud-services/tsc-transform-imports dev dependency to a newer version.
- Remove unused @types/redux-logger and webpack-bundle-analyzer dev dependencies from the project.