### PR TITLE
Add link to cloud accounts from marketplace purchases

### DIFF
--- a/src/Components/MarketPlacePurchases/MarketplacePurchasesTable.tsx
+++ b/src/Components/MarketPlacePurchases/MarketplacePurchasesTable.tsx
@@ -3,6 +3,9 @@ import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { formatDate } from '../../hooks/util/dates';
 import { MarketplacePurchase } from '../../hooks/api/useMarketplacePurchases';
 import { marketplaceToFriendly } from '../../hooks/util/cloudProviderMaps';
+import { Link } from 'react-router-dom';
+import { Paths } from '../../utils/routing';
+import { generateQueryParamsForData } from '../../hooks/util/useQueryParam';
 type MarketplacePurchasesTableProps = {
   marketplacePurchases: MarketplacePurchase[];
 };
@@ -54,7 +57,11 @@ export const MarketplacePurchasesTable = ({
           >
             <Td dataLabel="Offering name">{purchase.offeringName}</Td>
             <Td dataLabel="Marketplace account">
-              {purchase.marketplaceAccount}
+              <Link
+                to={`../${Paths.CloudAccounts}?${generateQueryParamsForData([purchase.marketplaceAccount], 'providerAccountID')}`}
+              >
+                {purchase.marketplaceAccount}
+              </Link>
             </Td>
             <Td dataLabel="Marketplace">
               {marketplaceToFriendly[purchase.marketplace] ??

--- a/src/Components/MarketPlacePurchases/__tests__/MarketplacePurchasesTable.test.tsx
+++ b/src/Components/MarketPlacePurchases/__tests__/MarketplacePurchasesTable.test.tsx
@@ -3,6 +3,7 @@ import { screen } from '@testing-library/react';
 import { renderWithRouter } from '../../../utils/testing/customRender';
 import { MarketplacePurchasesTable } from '../MarketplacePurchasesTable';
 import { MarketplacePurchase } from '../../../hooks/api/useMarketplacePurchases';
+import { Paths } from '../../../utils/routing';
 
 const makeMarketplacePurchases = (count: number): MarketplacePurchase[] =>
   Array.from({ length: count }).map((_, index) => ({
@@ -52,5 +53,30 @@ describe('MarketplacePurchasesTable', () => {
 
     expect(screen.getByText('2026-01-01')).toBeInTheDocument();
     expect(screen.getByText('2026-01-02')).toBeInTheDocument();
+  });
+
+  describe('cloud account link', () => {
+    it('renders the link', () => {
+      const marketplacePurchases = makeMarketplacePurchases(2);
+      renderTable(marketplacePurchases);
+
+      expect(
+        screen
+          .getByText(marketplacePurchases[0].marketplaceAccount)
+          .getAttribute('href'),
+      ).not.toBeNull();
+    });
+    it('renders the link with expected query params', () => {
+      const marketplacePurchases = makeMarketplacePurchases(2);
+      renderTable(marketplacePurchases);
+
+      expect(
+        screen
+          .getByText(marketplacePurchases[0].marketplaceAccount)
+          .getAttribute('href'),
+      ).toBe(
+        `/${Paths.CloudAccounts}?providerAccountID=${encodeURI(`["${marketplacePurchases[0].marketplaceAccount}"]`)}`,
+      );
+    });
   });
 });


### PR DESCRIPTION
This adds a link to the cloud accounts page to the marketplace purchases table, pre-filtering the cloud accounts to the selected account.

## Summary by Sourcery

Add navigation from marketplace purchases to the corresponding cloud accounts page, pre-filtered by the selected marketplace account.

New Features:
- Link marketplace account entries in the purchases table to the cloud accounts view filtered by the selected provider account.

Tests:
- Add tests verifying the marketplace account cell renders as a link with the expected cloud accounts filter query parameters.