### PR TITLE
Create claudemd and apply consistent linting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,7 @@
 {
-    "singleQuote": true
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "printWidth": 100
 }
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+## Project Overview
+
+Cloud Inventory is a Red Hat Insights micro-frontend for viewing cloud account inventory, gold images, and marketplace purchases, served on `console.redhat.com` at `/subscriptions/cloud-inventory`. Built with React/TypeScript and loaded into the Insights Chrome shell via Webpack Module Federation (`fec` CLI).
+
+## Common Commands
+
+- `npm run start` — dev server with proxy (requires Red Hat VPN + proxy setup)
+- `npm run build` — production build
+- `npm run test` — run Jest tests
+- `npm run lint` — ESLint
+- `npm run verify` — build + lint + test (full CI check)
+
+## Architecture & Conventions
+
+- Functional components only, arrow functions, typed with `FC<Props>` or inline prop interfaces
+- PascalCase directories for Components and Pages; lowercase for hooks, utils, state, types
+- PatternFly v6 for UI components (`@patternfly/react-core`, `@patternfly/react-table`, `@patternfly/react-icons`)
+- Plain SCSS — custom styles auto-scoped under `.cloud-inventory` / `.cloudInventory` by `fec.config.js`
+- Native `fetch` + TanStack React Query v5 for data fetching; auth handled by the Chrome shell (no explicit token management needed in API calls)
+- React Router v6 with lazy loading for page-level routes
+- No Redux — React Query for server state, Jotai atoms for client-side filter/pagination state, React Context for notifications
+- URL-synced state: use `useQueryParamInformedAtom(atom, key)` to two-way sync a Jotai atom with a URL query parameter, or `useQueryParamInformedState(init, key)` for the same pattern with local `useState`. Both initialize from the URL on mount and update the URL on every setter call. Multiple query-param setters in the same tick are batched into a single URL update
+- Authorization via Kessel (`@project-kessel/react-kessel-access-check`) for relation-based access control; see `useHasRelation` hook
+- ESLint flat config with `sort-imports` rule (declaration sort is ignored, but member sort is enforced)
+- Prefer code reuse over duplication — extract shared logic into hooks or utilities
+- Prefer small, focused React components over large complex ones
+- Stay in scope — do not refactor or "improve" unrelated code when working on a feature
+
+## Testing
+
+- Jest 30 with ts-jest + React Testing Library
+- Tests colocated in `__tests__/` subdirectories next to the code they test
+- Coverage thresholds: 85% across branches, functions, and lines
+- New features must include unit tests
+- Do NOT use snapshot tests — test observable behavior and functionality (what the user sees and does), not implementation details (internal state, component structure, CSS classes)
+- Pre-existing test failures are a code smell — if existing tests break after your changes, investigate the unintended consequences rather than just updating the test to pass
+
+### Built-in Test Utilities
+
+Use the app's testing helpers instead of reimplementing wrappers:
+
+- **`renderWithRouter(ui)`** (`src/utils/testing/customRender.tsx`) — drop-in replacement for RTL's `render` that wraps the component in a `BrowserRouter`. Use for any component that uses routing or `useSearchParams`
+- **`renderHookWithRouter(hook)`** (`src/utils/testing/customRender.tsx`) — same as above but for `renderHook`. Composes with a custom wrapper option if you need additional providers
+- **`expectToThrow(fn)`** (`src/utils/testing/expectToThrow.ts`) — wraps an async function expected to throw, suppressing React's noisy `console.error` output during the test
+- **`HydrateAtomsTestProvider`** (`src/Components/util/testing/HydrateAtomsTestProvider.tsx`) — wraps components in a fresh Jotai `Provider` with pre-set atom values. Use when testing components that depend on Jotai atoms
+- **`RequestMocks`** (`src/Components/util/testing/mockApiResponse.tsx`) — class that mocks `global.fetch` and provides a React Query `wrapper` for hook tests. Call `addMock(url, payload)` to register responses, and use its `.wrapper` with `renderHook`. Also exports standalone `enableMocks()` / `mockApiResponse()` / `resetMocks()` helpers for simpler cases
+- **`__resetQueryParamBatchforTests()`** (`src/hooks/util/useQueryParam.ts`) — resets the internal microtask batching state for query param hooks between tests
+
+## Key Caveats
+
+- Pre-commit hook runs ESLint via husky/lint-staged on staged files
+- App runs inside Red Hat Insights Chrome shell — `useChrome()` provides auth, navigation, document title, and environment
+- `useChrome()` is globally mocked in `config/jest.setup.ts` for all tests
+- Local dev requires Red Hat VPN and proxy setup
+- `fec.config.js` configures Webpack/Module Federation — app is served under `/subscriptions/cloud-inventory`
+- API calls go to `/api/rhsm/v2/` (subscription manager) and `/api/kessel/v1beta2` (authorization)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,10 +19,7 @@ const App = () => {
 
   return (
     <Fragment>
-      <AccessCheck.Provider
-        baseUrl={window.location.origin}
-        apiPath="/api/kessel/v1beta2"
-      >
+      <AccessCheck.Provider baseUrl={window.location.origin} apiPath="/api/kessel/v1beta2">
         <QueryClientProvider client={queryClient}>
           <NotificationsProvider />
           <Routing />

--- a/src/Components/CloudAccounts/CloudAccountIDFilter.tsx
+++ b/src/Components/CloudAccounts/CloudAccountIDFilter.tsx
@@ -6,7 +6,7 @@ import { cloudAccountIDFilterData } from '../../state/cloudAccounts';
 export const CloudAccountIDFilter = () => {
   const [accountIDFilter, setAccountIDFilter] = useQueryParamInformedAtom(
     cloudAccountIDFilterData,
-    'providerAccountID',
+    'providerAccountID'
   );
 
   const timerRef = useRef<ReturnType<typeof setTimeout>>();

--- a/src/Components/CloudAccounts/CloudAccountProviderFilter.tsx
+++ b/src/Components/CloudAccounts/CloudAccountProviderFilter.tsx
@@ -5,25 +5,22 @@ import {
   Select,
   SelectList,
   SelectOption,
-  ToolbarItem,
+  ToolbarItem
 } from '@patternfly/react-core';
 import { cloudProviderFilterData } from '../../state/cloudAccounts';
 import { useQueryParamInformedAtom } from '../../hooks/util/useQueryParam';
-import {
-  CloudProviderShortname,
-  ProviderLabelMap,
-} from '../../types/cloudAccountsTypes';
+import { CloudProviderShortname, ProviderLabelMap } from '../../types/cloudAccountsTypes';
 
 interface CloudAccountProviderFilterProps {
   availableProviders: CloudProviderShortname[];
 }
 
-export const CloudAccountProviderFilter: React.FC<
-  CloudAccountProviderFilterProps
-> = ({ availableProviders }) => {
+export const CloudAccountProviderFilter: React.FC<CloudAccountProviderFilterProps> = ({
+  availableProviders
+}) => {
   const [selectedProviders, setSelectedProviders] = useQueryParamInformedAtom(
     cloudProviderFilterData,
-    'shortName',
+    'shortName'
   );
   const [isOpen, setIsOpen] = useState(false);
 
@@ -31,10 +28,7 @@ export const CloudAccountProviderFilter: React.FC<
     setIsOpen((prev) => !prev);
   };
 
-  const onSelect = (
-    _event: React.MouseEvent | undefined,
-    value: string | number | undefined,
-  ) => {
+  const onSelect = (_event: React.MouseEvent | undefined, value: string | number | undefined) => {
     if (!value || typeof value !== 'string') {
       setIsOpen(false);
       return;
@@ -58,11 +52,7 @@ export const CloudAccountProviderFilter: React.FC<
         onSelect={onSelect}
         selected={selectedProviders}
         toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-          <MenuToggle
-            ref={toggleRef}
-            onClick={onToggleClick}
-            isExpanded={isOpen}
-          >
+          <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
                         Filter by cloud provider           
           </MenuToggle>
         )}

--- a/src/Components/CloudAccounts/CloudAccountsFilterList.tsx
+++ b/src/Components/CloudAccounts/CloudAccountsFilterList.tsx
@@ -5,12 +5,12 @@ import {
   LabelGroup,
   ToolbarContent,
   ToolbarGroup,
-  ToolbarItem,
+  ToolbarItem
 } from '@patternfly/react-core';
 import {
   cloudAccountIDFilterData,
   cloudProviderFilterData,
-  goldImageStatusFilterData,
+  goldImageStatusFilterData
 } from '../../state/cloudAccounts';
 import { ProviderLabelMap } from '../../types/cloudAccountsTypes';
 import { useQueryParamInformedAtom } from '../../hooks/util/useQueryParam';
@@ -21,29 +21,27 @@ type FilterCategory = 'ID' | 'Provider' | 'Status';
 const FILTER_LABELS: Record<FilterCategory, string> = {
   ID: 'Cloud account',
   Provider: 'Cloud provider',
-  Status: 'Gold image access',
+  Status: 'Gold image access'
 };
 
 export const CloudAccountsFilterList = () => {
   const [selectedProviders, setSelectedProviders] = useQueryParamInformedAtom(
     cloudProviderFilterData,
-    'shortName',
+    'shortName'
   );
   const [selectedStatuses, setSelectedStatuses] = useQueryParamInformedAtom(
     goldImageStatusFilterData,
-    'goldImageAccess',
+    'goldImageAccess'
   );
   const [selectedID, setSelectedID] = useQueryParamInformedAtom(
     cloudAccountIDFilterData,
-    'providerAccountID',
+    'providerAccountID'
   );
 
   const clearFilters = useClearCloudAccountFilters();
 
   const hasActiveFilters =
-    selectedID !== '' ||
-    selectedProviders.length > 0 ||
-    selectedStatuses.length > 0;
+    selectedID !== '' || selectedProviders.length > 0 || selectedStatuses.length > 0;
 
   return (
     <ToolbarContent>
@@ -59,9 +57,7 @@ export const CloudAccountsFilterList = () => {
               <Label
                 key={provider}
                 onClose={() =>
-                  setSelectedProviders(
-                    selectedProviders.filter((p) => p !== provider),
-                  )
+                  setSelectedProviders(selectedProviders.filter((p) => p !== provider))
                 }
               >
                 {ProviderLabelMap[provider] ?? provider}
@@ -74,11 +70,7 @@ export const CloudAccountsFilterList = () => {
             {selectedStatuses.map((status) => (
               <Label
                 key={status}
-                onClose={() =>
-                  setSelectedStatuses(
-                    selectedStatuses.filter((s) => s !== status),
-                  )
-                }
+                onClose={() => setSelectedStatuses(selectedStatuses.filter((s) => s !== status))}
               >
                 {status}
               </Label>

--- a/src/Components/CloudAccounts/CloudAccountsPagination.tsx
+++ b/src/Components/CloudAccounts/CloudAccountsPagination.tsx
@@ -3,7 +3,5 @@ import { CloudAccountsPaginationData } from '../../state/cloudAccounts';
 import { PaginationBase } from '../shared/PaginationBase';
 
 export const CloudAccountsPagination = ({ isCompact = false }) => {
-  return (
-    <PaginationBase atom={CloudAccountsPaginationData} isCompact={isCompact} />
-  );
+  return <PaginationBase atom={CloudAccountsPaginationData} isCompact={isCompact} />;
 };

--- a/src/Components/CloudAccounts/CloudAccountsTable.tsx
+++ b/src/Components/CloudAccounts/CloudAccountsTable.tsx
@@ -1,13 +1,5 @@
 import React from 'react';
-import {
-  SortByDirection,
-  Table,
-  Tbody,
-  Td,
-  Th,
-  Thead,
-  Tr,
-} from '@patternfly/react-table';
+import { SortByDirection, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { Button, Content } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { CloudAccountRow } from './types';
@@ -15,13 +7,10 @@ import { CloudAccountStatus, getStatusIcon } from './GetStatusIcon';
 import { formatDate } from '../../hooks/util/dates';
 import {
   generateQueryParamsForData,
-  useQueryParamInformedAtom,
+  useQueryParamInformedAtom
 } from '../../hooks/util/useQueryParam';
 import { shortToFriendly } from '../../hooks/util/cloudProviderMaps';
-import {
-  CloudAccountsPaginationData,
-  CloudAccountsSortField,
-} from '../../state/cloudAccounts';
+import { CloudAccountsPaginationData, CloudAccountsSortField } from '../../state/cloudAccounts';
 import { useApiBasedTableSort } from '../../hooks/util/tables/useTableSort';
 import { hasPaginationError } from '../../utils/errors';
 import { PaginationError } from '../shared/PaginationError';
@@ -53,19 +42,19 @@ export const CloudAccountsTable = ({
   sortBy,
   setSortBy,
   sortDir,
-  setSortDir,
+  setSortDir
 }: CloudAccountProps) => {
   const rows: CloudAccountRow[] = cloudAccounts.map((acct) => ({
     id: acct.providerAccountID,
     provider: shortToFriendly[acct.shortName],
     goldImage: acct.goldImageAccess as CloudAccountStatus,
     date: acct.dateAdded,
-    sourceID: acct.sourceID,
+    sourceID: acct.sourceID
   }));
 
   const [pagination, setPagination] = useQueryParamInformedAtom(
     CloudAccountsPaginationData,
-    'pagination',
+    'pagination'
   );
 
   const displayRows = rows;
@@ -80,14 +69,12 @@ export const CloudAccountsTable = ({
       0: 'providerAccountID',
       1: 'shortName',
       2: 'goldImageAccess',
-      3: 'dateAdded',
-    },
+      3: 'dateAdded'
+    }
   });
 
   if (onInvalidPage) {
-    return (
-      <PaginationError pagination={pagination} setPagination={setPagination} />
-    );
+    return <PaginationError pagination={pagination} setPagination={setPagination} />;
   }
 
   return (
@@ -106,9 +93,7 @@ export const CloudAccountsTable = ({
           <Tr key={row.id}>
             <Td>
               {row.sourceID && (
-                <Link to={`/settings/integrations/detail/${row.sourceID}`}>
-                  {row.id}
-                </Link>
+                <Link to={`/settings/integrations/detail/${row.sourceID}`}>{row.id}</Link>
               )}
               {!row.sourceID && row.id}
             </Td>
@@ -116,10 +101,7 @@ export const CloudAccountsTable = ({
               <Link
                 to={{
                   pathname: '/subscriptions/cloud-inventory/gold-images',
-                  search: generateQueryParamsForData(
-                    [row.provider],
-                    'cloudProvider',
-                  ).toString(),
+                  search: generateQueryParamsForData([row.provider], 'cloudProvider').toString()
                 }}
               >
                 {row.provider}

--- a/src/Components/CloudAccounts/CloudAccountsToolbar.tsx
+++ b/src/Components/CloudAccounts/CloudAccountsToolbar.tsx
@@ -8,7 +8,7 @@ import {
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
-  ToolbarItem,
+  ToolbarItem
 } from '@patternfly/react-core';
 import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
 import { CloudAccountIDFilter } from './CloudAccountIDFilter';
@@ -30,22 +30,22 @@ type FilterCategory = 'ID' | 'Provider' | 'Status';
 const FILTER_LABELS: Record<FilterCategory, string> = {
   ID: 'Cloud account',
   Provider: 'Cloud provider',
-  Status: 'Gold image access',
+  Status: 'Gold image access'
 };
 
 export const CloudAccountsToolbar: React.FC<CloudAccountsToolbarProps> = ({
   availableProviders,
-  availableStatuses,
+  availableStatuses
 }) => {
   const [activeCategory, setActiveCategory] = useQueryParamInformedAtom(
     cloudAccountsFilterCategoryData,
-    'filterCategory',
+    'filterCategory'
   );
   const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] = useState(false);
 
   const onCategorySelect = (
     _event: React.MouseEvent | undefined,
-    value: string | number | undefined,
+    value: string | number | undefined
   ) => {
     if (!value) {
       return;
@@ -80,21 +80,17 @@ export const CloudAccountsToolbar: React.FC<CloudAccountsToolbarProps> = ({
               toggle={categoryToggle}
             >
               <SelectList>
-                {(Object.keys(FILTER_LABELS) as FilterCategory[]).map(
-                  (category) => (
-                    <SelectOption key={category} value={category}>
-                      {FILTER_LABELS[category]}
-                    </SelectOption>
-                  ),
-                )}
+                {(Object.keys(FILTER_LABELS) as FilterCategory[]).map((category) => (
+                  <SelectOption key={category} value={category}>
+                    {FILTER_LABELS[category]}
+                  </SelectOption>
+                ))}
               </SelectList>
             </Select>
           </ToolbarItem>
           {activeCategory === 'ID' && <CloudAccountIDFilter />}
           {activeCategory === 'Provider' && (
-            <CloudAccountProviderFilter
-              availableProviders={availableProviders}
-            />
+            <CloudAccountProviderFilter availableProviders={availableProviders} />
           )}
           {activeCategory === 'Status' && (
             <ToolbarItem>

--- a/src/Components/CloudAccounts/GetStatusIcon.tsx
+++ b/src/Components/CloudAccounts/GetStatusIcon.tsx
@@ -1,14 +1,10 @@
-import {
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-  WrenchIcon,
-} from '@patternfly/react-icons';
+import { CheckCircleIcon, ExclamationCircleIcon, WrenchIcon } from '@patternfly/react-icons';
 import React from 'react';
 
 export enum CloudAccountStatus {
   Granted = 'Granted',
   Failed = 'Failed',
-  Requested = 'Requested',
+  Requested = 'Requested'
 }
 
 export const getStatusIcon = (status: CloudAccountStatus, label: string) => {
@@ -17,9 +13,7 @@ export const getStatusIcon = (status: CloudAccountStatus, label: string) => {
       return <CheckCircleIcon color="green" aria-label={label} title={label} />;
 
     case CloudAccountStatus.Failed:
-      return (
-        <ExclamationCircleIcon color="red" aria-label={label} title={label} />
-      );
+      return <ExclamationCircleIcon color="red" aria-label={label} title={label} />;
 
     case CloudAccountStatus.Requested:
       return <WrenchIcon color="black" aria-label={label} title={label} />;

--- a/src/Components/CloudAccounts/GoldImageAccessFilter.tsx
+++ b/src/Components/CloudAccounts/GoldImageAccessFilter.tsx
@@ -4,7 +4,7 @@ import {
   MenuToggleElement,
   Select,
   SelectList,
-  SelectOption,
+  SelectOption
 } from '@patternfly/react-core';
 import { useQueryParamInformedAtom } from '../../hooks/util/useQueryParam';
 import { goldImageStatusFilterData } from '../../state/cloudAccounts';
@@ -13,19 +13,14 @@ interface GoldImageAccessFilterProps {
   availableStatuses: string[];
 }
 
-export const GoldImageAccessFilter = ({
-  availableStatuses,
-}: GoldImageAccessFilterProps) => {
+export const GoldImageAccessFilter = ({ availableStatuses }: GoldImageAccessFilterProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedStatuses, setSelectedStatuses] = useQueryParamInformedAtom(
     goldImageStatusFilterData,
-    'goldImageAccess',
+    'goldImageAccess'
   );
 
-  const onSelect = (
-    _event: React.MouseEvent | undefined,
-    value: string | number | undefined,
-  ) => {
+  const onSelect = (_event: React.MouseEvent | undefined, value: string | number | undefined) => {
     if (!value || typeof value !== 'string') {
       return;
     }
@@ -48,7 +43,7 @@ export const GoldImageAccessFilter = ({
           onClick={() => setIsOpen((prev) => !prev)}
           isExpanded={isOpen}
           {...(selectedStatuses.length > 0 && {
-            badge: selectedStatuses.length,
+            badge: selectedStatuses.length
           })}
         >
           {selectedStatuses.length === 0 ? 'Filter by status' : 'Status'}

--- a/src/Components/CloudAccounts/NoCloudAccounts.tsx
+++ b/src/Components/CloudAccounts/NoCloudAccounts.tsx
@@ -1,26 +1,15 @@
-import {
-  Button,
-  EmptyState,
-  EmptyStateActions,
-  EmptyStateBody,
-} from '@patternfly/react-core';
+import { Button, EmptyState, EmptyStateActions, EmptyStateBody } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { Link } from 'react-router-dom';
 
 export const NoCloudAccounts = () => (
-  <EmptyState
-    variant="lg"
-    titleText="Cloud Accounts Available"
-    headingLevel="h4"
-    icon={CubesIcon}
-  >
+  <EmptyState variant="lg" titleText="Cloud Accounts Available" headingLevel="h4" icon={CubesIcon}>
     <EmptyStateBody>
       Cloud accounts appear here when they are connected through{' '}
-      <Link to="/settings/integrations/">Integrations</Link>. Additionally,
-      accounts will show up here if auto-registration or gold image access is
-      initiated on the cloud provider. Please refer to the documentation for
-      further guidance.
+      <Link to="/settings/integrations/">Integrations</Link>. Additionally, accounts will show up
+      here if auto-registration or gold image access is initiated on the cloud provider. Please
+      refer to the documentation for further guidance.
     </EmptyStateBody>
     <EmptyStateActions>
       <Button variant="link">View documentation</Button>

--- a/src/Components/CloudAccounts/__tests__/CloudAccountIDFilter.test.tsx
+++ b/src/Components/CloudAccounts/__tests__/CloudAccountIDFilter.test.tsx
@@ -6,9 +6,7 @@ import { CloudAccountIDFilter } from '../CloudAccountIDFilter';
 import { cloudAccountIDFilterData } from '../../../state/cloudAccounts';
 
 const CloudAccountIDFilterWithState = ({ initialValue = '' }) => (
-  <HydrateAtomsTestProvider
-    initialValues={[[cloudAccountIDFilterData, initialValue]]}
-  >
+  <HydrateAtomsTestProvider initialValues={[[cloudAccountIDFilterData, initialValue]]}>
     <CloudAccountIDFilter />
   </HydrateAtomsTestProvider>
 );
@@ -17,9 +15,7 @@ describe('CloudAccountIDFilter filter', () => {
   it('displays the correct account id when state is "123"', () => {
     renderWithRouter(<CloudAccountIDFilterWithState initialValue="123" />);
 
-    const input = screen.getByPlaceholderText(
-      'Filter by cloud account ID',
-    ) as HTMLInputElement;
+    const input = screen.getByPlaceholderText('Filter by cloud account ID') as HTMLInputElement;
     expect(input.value).toBe('123');
   });
 
@@ -33,9 +29,7 @@ describe('CloudAccountIDFilter filter', () => {
 
   it('clears the input value when the "x" (reset) button is clicked', async () => {
     renderWithRouter(<CloudAccountIDFilterWithState initialValue="781" />);
-    const input = screen.getByPlaceholderText(
-      'Filter by cloud account ID',
-    ) as HTMLInputElement;
+    const input = screen.getByPlaceholderText('Filter by cloud account ID') as HTMLInputElement;
     expect(input.value).toBe('781');
     const clearButton = screen.getByRole('button', { name: /reset/i });
     fireEvent.click(clearButton);
@@ -49,8 +43,6 @@ describe('CloudAccountIDFilter filter', () => {
 
     const input = screen.getByPlaceholderText('Filter by cloud account ID');
     expect(input).toHaveValue('');
-    expect(
-      screen.queryByRole('button', { name: /reset/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /reset/i })).not.toBeInTheDocument();
   });
 });

--- a/src/Components/CloudAccounts/__tests__/CloudAccountProviderFilter.test.tsx
+++ b/src/Components/CloudAccounts/__tests__/CloudAccountProviderFilter.test.tsx
@@ -10,11 +10,11 @@ import { CloudProviderShortname } from '../../../types/cloudAccountsTypes';
 const availableProviders = [
   CloudProviderShortname.AWS,
   CloudProviderShortname.GCP,
-  CloudProviderShortname.AZURE,
+  CloudProviderShortname.AZURE
 ];
 
 const CloudAccountProviderFilterWithState = ({
-  init = [],
+  init = []
 }: {
   init?: CloudProviderShortname[];
 }) => (
@@ -24,7 +24,7 @@ const CloudAccountProviderFilterWithState = ({
 );
 
 const CloudAccountProviderFilterWithStateObserver = ({
-  init = [],
+  init = []
 }: {
   init?: CloudProviderShortname[];
 }) => {
@@ -55,17 +55,13 @@ describe('CloudAccountProviderFilter', () => {
   it('renders the provider filter toggle', () => {
     renderWithRouter(<CloudAccountProviderFilterWithState />);
 
-    expect(
-      screen.getByRole('button', { name: /filter by cloud provider/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /filter by cloud provider/i })).toBeInTheDocument();
   });
 
   it('renders available provider options when opened', async () => {
     renderWithRouter(<CloudAccountProviderFilterWithState />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: /filter by cloud provider/i }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: /filter by cloud provider/i }));
 
     await waitFor(() => {
       expect(screen.getByText('AWS')).toBeInTheDocument();
@@ -77,9 +73,7 @@ describe('CloudAccountProviderFilter', () => {
   it('selects a provider', async () => {
     renderWithRouter(<CloudAccountProviderFilterWithStateObserver />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: /filter by cloud provider/i }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: /filter by cloud provider/i }));
 
     await waitFor(() => {
       expect(screen.getByText('AWS')).toBeInTheDocument();
@@ -88,18 +82,14 @@ describe('CloudAccountProviderFilter', () => {
     fireEvent.click(screen.getByText('AWS'));
 
     await waitFor(() => {
-      expect(screen.getByTestId('selected-providers')).toHaveTextContent(
-        '["AWS"]',
-      );
+      expect(screen.getByTestId('selected-providers')).toHaveTextContent('["AWS"]');
     });
   });
 
   it('supports selecting multiple providers', async () => {
     renderWithRouter(<CloudAccountProviderFilterWithStateObserver />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: /filter by cloud provider/i }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: /filter by cloud provider/i }));
 
     await waitFor(() => {
       expect(screen.getByText('AWS')).toBeInTheDocument();
@@ -109,23 +99,19 @@ describe('CloudAccountProviderFilter', () => {
     fireEvent.click(screen.getByText('Google Compute Engine'));
 
     await waitFor(() => {
-      expect(screen.getByTestId('selected-providers')).toHaveTextContent(
-        '["AWS","GCE"]',
-      );
+      expect(screen.getByTestId('selected-providers')).toHaveTextContent('["AWS","GCE"]');
     });
   });
 
   it('adds another provider when selected from the dropdown', async () => {
     renderWithRouter(
-      <CloudAccountProviderFilterWithStateObserver
-        init={[CloudProviderShortname.AWS]}
-      />,
+      <CloudAccountProviderFilterWithStateObserver init={[CloudProviderShortname.AWS]} />
     );
 
     fireEvent.click(
       screen.getByRole('button', {
-        name: /filter by cloud provider|cloud provider/i,
-      }),
+        name: /filter by cloud provider|cloud provider/i
+      })
     );
 
     await waitFor(() => {
@@ -135,22 +121,16 @@ describe('CloudAccountProviderFilter', () => {
     fireEvent.click(screen.getByText('Google Compute Engine'));
 
     await waitFor(() => {
-      expect(screen.getByTestId('selected-providers')).toHaveTextContent(
-        '["AWS","GCE"]',
-      );
+      expect(screen.getByTestId('selected-providers')).toHaveTextContent('["AWS","GCE"]');
     });
   });
 
   it('preserves existing selections and adds another provider', async () => {
     renderWithRouter(
-      <CloudAccountProviderFilterWithStateObserver
-        init={[CloudProviderShortname.AWS]}
-      />,
+      <CloudAccountProviderFilterWithStateObserver init={[CloudProviderShortname.AWS]} />
     );
 
-    fireEvent.click(
-      screen.getByRole('button', { name: /filter by cloud provider/i }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: /filter by cloud provider/i }));
 
     await waitFor(() => {
       expect(screen.getByText('Google Compute Engine')).toBeInTheDocument();
@@ -159,18 +139,14 @@ describe('CloudAccountProviderFilter', () => {
     fireEvent.click(screen.getByText('Google Compute Engine'));
 
     await waitFor(() => {
-      expect(screen.getByTestId('selected-providers')).toHaveTextContent(
-        '["AWS","GCE"]',
-      );
+      expect(screen.getByTestId('selected-providers')).toHaveTextContent('["AWS","GCE"]');
     });
   });
 
   it('shows provider display labels instead of raw shortnames in the menu', async () => {
     renderWithRouter(<CloudAccountProviderFilterWithState />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: /filter by cloud provider/i }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: /filter by cloud provider/i }));
 
     await waitFor(() => {
       expect(screen.getByText('Google Compute Engine')).toBeInTheDocument();

--- a/src/Components/CloudAccounts/__tests__/CloudAccountsFilterList.test.tsx
+++ b/src/Components/CloudAccounts/__tests__/CloudAccountsFilterList.test.tsx
@@ -6,14 +6,14 @@ import { CloudAccountsFilterList } from '../CloudAccountsFilterList';
 import {
   cloudAccountIDFilterData,
   cloudProviderFilterData,
-  goldImageStatusFilterData,
+  goldImageStatusFilterData
 } from '../../../state/cloudAccounts';
 import { CloudProviderShortname } from '../../../types/cloudAccountsTypes';
 
 const renderFilterList = ({
   selectedID = '',
   selectedProviders = [],
-  selectedStatuses = [],
+  selectedStatuses = []
 }: {
   selectedID?: string;
   selectedProviders?: string[];
@@ -24,13 +24,13 @@ const renderFilterList = ({
       initialValues={[
         [cloudAccountIDFilterData, selectedID],
         [cloudProviderFilterData, selectedProviders],
-        [goldImageStatusFilterData, selectedStatuses],
+        [goldImageStatusFilterData, selectedStatuses]
       ]}
     >
             
       <CloudAccountsFilterList />
           
-    </HydrateAtomsTestProvider>,
+    </HydrateAtomsTestProvider>
   );
 
 beforeEach(() => {
@@ -41,9 +41,7 @@ describe('CloudAccountsFilterList', () => {
   it('renders nothing filter-related when no filters are active', () => {
     renderFilterList();
 
-    expect(
-      screen.queryByRole('button', { name: /clear all filters/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /clear all filters/i })).not.toBeInTheDocument();
     expect(screen.queryByText('Cloud account')).not.toBeInTheDocument();
     expect(screen.queryByText('Cloud provider')).not.toBeInTheDocument();
     expect(screen.queryByText('Gold image access')).not.toBeInTheDocument();
@@ -58,10 +56,7 @@ describe('CloudAccountsFilterList', () => {
 
   it('renders selected provider filters using display labels', () => {
     renderFilterList({
-      selectedProviders: [
-        CloudProviderShortname.AWS,
-        CloudProviderShortname.GCP,
-      ],
+      selectedProviders: [CloudProviderShortname.AWS, CloudProviderShortname.GCP]
     });
 
     expect(screen.getByText('Cloud provider')).toBeInTheDocument();
@@ -71,7 +66,7 @@ describe('CloudAccountsFilterList', () => {
 
   it('renders selected status filters', () => {
     renderFilterList({
-      selectedStatuses: ['Granted', 'Failed'],
+      selectedStatuses: ['Granted', 'Failed']
     });
 
     expect(screen.getByText('Gold image access')).toBeInTheDocument();
@@ -84,9 +79,7 @@ describe('CloudAccountsFilterList', () => {
 
     const closeButtons = screen
       .getAllByRole('button')
-      .filter((button) =>
-        button.getAttribute('aria-label')?.toLowerCase().includes('close'),
-      );
+      .filter((button) => button.getAttribute('aria-label')?.toLowerCase().includes('close'));
 
     expect(closeButtons.length).toBeGreaterThan(0);
 
@@ -100,7 +93,7 @@ describe('CloudAccountsFilterList', () => {
     renderFilterList({
       selectedID: 'acct-123',
       selectedProviders: [CloudProviderShortname.AWS],
-      selectedStatuses: ['Granted'],
+      selectedStatuses: ['Granted']
     });
 
     fireEvent.click(screen.getByRole('button', { name: /clear all filters/i }));
@@ -118,14 +111,10 @@ describe('CloudAccountsFilterList', () => {
 
     const closeButtons = screen
       .getAllByRole('button')
-      .filter((button) =>
-        button.getAttribute('aria-label')?.toLowerCase().includes('close'),
-      );
+      .filter((button) => button.getAttribute('aria-label')?.toLowerCase().includes('close'));
 
     fireEvent.click(closeButtons[0]);
 
-    expect(
-      screen.queryByRole('button', { name: /clear all filters/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /clear all filters/i })).not.toBeInTheDocument();
   });
 });

--- a/src/Components/CloudAccounts/__tests__/CloudAccountsTable.test.tsx
+++ b/src/Components/CloudAccounts/__tests__/CloudAccountsTable.test.tsx
@@ -5,31 +5,24 @@ import { CloudAccountsPaginationData } from '../../../state/cloudAccounts';
 import { HydrateAtomsTestProvider } from '../../util/testing/HydrateAtomsTestProvider';
 import { renderWithRouter } from '../../../utils/testing/customRender';
 import { SortByDirection } from '@patternfly/react-table';
-import {
-  CloudAccount,
-  CloudProviderShortname,
-} from '../../../types/cloudAccountsTypes';
+import { CloudAccount, CloudProviderShortname } from '../../../types/cloudAccountsTypes';
 
 jest.mock('../../../Components/CloudAccounts/GetStatusIcon', () => ({
-  getStatusIcon: () => <span data-testid="status-icon" />,
+  getStatusIcon: () => <span data-testid="status-icon" />
 }));
 
 jest.mock('../../../hooks/util/dates', () => ({
-  formatDate: (d: string) => `Formatted:${d}`,
+  formatDate: (d: string) => `Formatted:${d}`
 }));
 
-const makeAccounts = (
-  count: number,
-  hasSourceId: boolean = true,
-): CloudAccount[] =>
+const makeAccounts = (count: number, hasSourceId: boolean = true): CloudAccount[] =>
   Array.from({ length: count }).map((_, i) => ({
     providerAccountID: `acct-${i}`,
-    shortName:
-      i % 2 === 0 ? CloudProviderShortname.AWS : CloudProviderShortname.GCP,
+    shortName: i % 2 === 0 ? CloudProviderShortname.AWS : CloudProviderShortname.GCP,
     providerLabel: i % 2 === 0 ? 'AWS' : 'Google Cloud',
     goldImageAccess: i % 2 === 0 ? 'Granted' : 'Failed',
     dateAdded: `2024-01-${String(i + 1).padStart(2, '0')}`,
-    sourceID: hasSourceId ? 'source-id' : undefined,
+    sourceID: hasSourceId ? 'source-id' : undefined
   }));
 
 const TestTableComponent = ({ accounts }: { accounts: CloudAccount[] }) => {
@@ -55,17 +48,14 @@ const TestTableComponent = ({ accounts }: { accounts: CloudAccount[] }) => {
           }
 
           return sortDir == SortByDirection.asc ? result : result * -1;
-        }),
+        })
       );
   }, [sortBy, sortDir]);
 
   return (
     <HydrateAtomsTestProvider
       initialValues={[
-        [
-          CloudAccountsPaginationData,
-          { page: 1, perPage: 10, itemCount: accounts.length },
-        ],
+        [CloudAccountsPaginationData, { page: 1, perPage: 10, itemCount: accounts.length }]
       ]}
     >
       <CloudAccountsTable
@@ -85,9 +75,7 @@ const renderTable = (accounts: CloudAccount[]) =>
 describe('CloudAccountsTable', () => {
   it('renders the table', () => {
     renderTable(makeAccounts(3));
-    expect(
-      screen.getByRole('grid', { name: /cloud accounts table/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('grid', { name: /cloud accounts table/i })).toBeInTheDocument();
   });
 
   it('renders provider link with cloudProvider query param', () => {
@@ -113,7 +101,7 @@ describe('CloudAccountsTable', () => {
     renderTable(makeAccounts(1));
     expect(screen.getByText('acct-0')).toBeInTheDocument();
     expect(screen.getByText('acct-0').closest('a')?.href).toContain(
-      '/settings/integrations/detail/source-id',
+      '/settings/integrations/detail/source-id'
     );
   });
 
@@ -130,21 +118,14 @@ describe('CloudAccountsTable', () => {
 
   it('does not render pagination error when on valid page', () => {
     renderTable(makeAccounts(25));
-    expect(
-      screen.queryByText(/No results for current page/i),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/No results for current page/i)).not.toBeInTheDocument();
   });
 
   it('renders pagination error when page exceeds item count', () => {
     const accounts = makeAccounts(5);
     renderWithRouter(
       <HydrateAtomsTestProvider
-        initialValues={[
-          [
-            CloudAccountsPaginationData,
-            { page: 10, perPage: 10, itemCount: 5 },
-          ],
-        ]}
+        initialValues={[[CloudAccountsPaginationData, { page: 10, perPage: 10, itemCount: 5 }]]}
       >
         <CloudAccountsTable
           cloudAccounts={accounts}
@@ -153,27 +134,18 @@ describe('CloudAccountsTable', () => {
           sortDir={SortByDirection.asc}
           setSortDir={() => {}}
         />
-      </HydrateAtomsTestProvider>,
+      </HydrateAtomsTestProvider>
     );
 
-    expect(
-      screen.getByText(/No results for current page/i),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: /return to page 1/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/No results for current page/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /return to page 1/i })).toBeInTheDocument();
   });
 
   it('does not render table content when pagination error is shown', () => {
     const accounts = makeAccounts(5);
     renderWithRouter(
       <HydrateAtomsTestProvider
-        initialValues={[
-          [
-            CloudAccountsPaginationData,
-            { page: 10, perPage: 10, itemCount: 5 },
-          ],
-        ]}
+        initialValues={[[CloudAccountsPaginationData, { page: 10, perPage: 10, itemCount: 5 }]]}
       >
         <CloudAccountsTable
           cloudAccounts={accounts}
@@ -182,7 +154,7 @@ describe('CloudAccountsTable', () => {
           sortDir={SortByDirection.asc}
           setSortDir={() => {}}
         />
-      </HydrateAtomsTestProvider>,
+      </HydrateAtomsTestProvider>
     );
 
     expect(screen.queryByText('Cloud account')).not.toBeInTheDocument();
@@ -194,12 +166,7 @@ describe('CloudAccountsTable', () => {
 
     renderWithRouter(
       <HydrateAtomsTestProvider
-        initialValues={[
-          [
-            CloudAccountsPaginationData,
-            { page: 10, perPage: 10, itemCount: 5 },
-          ],
-        ]}
+        initialValues={[[CloudAccountsPaginationData, { page: 10, perPage: 10, itemCount: 5 }]]}
       >
         <CloudAccountsTable
           cloudAccounts={accounts}
@@ -208,22 +175,16 @@ describe('CloudAccountsTable', () => {
           sortDir={SortByDirection.asc}
           setSortDir={() => {}}
         />
-      </HydrateAtomsTestProvider>,
+      </HydrateAtomsTestProvider>
     );
 
-    expect(
-      screen.getByText(/No results for current page/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/No results for current page/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /return to page 1/i }));
 
-    expect(
-      screen.queryByText(/No results for current page/i),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/No results for current page/i)).not.toBeInTheDocument();
 
-    await waitFor(() =>
-      expect(screen.getAllByText(accounts[0].shortName)[0]).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getAllByText(accounts[0].shortName)[0]).toBeInTheDocument());
   });
 
   describe('mapField', () => {
@@ -248,81 +209,53 @@ describe('CloudAccountsTable', () => {
     it('by cloud account id', () => {
       const { container } = renderTable(makeAccounts(3));
       fireEvent.click(screen.getByRole('button', { name: /cloud account/i }));
-      expect(
-        String(
-          container.querySelector('tbody')?.firstChild?.childNodes[0]
-            .textContent,
-        ),
-      ).toBe('acct-0');
+      expect(String(container.querySelector('tbody')?.firstChild?.childNodes[0].textContent)).toBe(
+        'acct-0'
+      );
 
       fireEvent.click(screen.getByRole('button', { name: /cloud account/i }));
-      expect(
-        String(
-          container.querySelector('tbody')?.firstChild?.childNodes[0]
-            .textContent,
-        ),
-      ).toBe('acct-2');
+      expect(String(container.querySelector('tbody')?.firstChild?.childNodes[0].textContent)).toBe(
+        'acct-2'
+      );
     });
 
     it('by cloud provider', () => {
       const { container } = renderTable(makeAccounts(3));
       fireEvent.click(screen.getByRole('button', { name: /cloud provider/i }));
-      expect(
-        String(
-          container.querySelector('tbody')?.firstChild?.childNodes[1]
-            .textContent,
-        ),
-      ).toBe('AWS');
+      expect(String(container.querySelector('tbody')?.firstChild?.childNodes[1].textContent)).toBe(
+        'AWS'
+      );
 
       fireEvent.click(screen.getByRole('button', { name: /cloud provider/i }));
-      expect(
-        String(
-          container.querySelector('tbody')?.firstChild?.childNodes[1]
-            .textContent,
-        ),
-      ).toBe('Google Compute Engine');
+      expect(String(container.querySelector('tbody')?.firstChild?.childNodes[1].textContent)).toBe(
+        'Google Compute Engine'
+      );
     });
 
     it('by gold image', () => {
       const { container } = renderTable(makeAccounts(3));
-      fireEvent.click(
-        screen.getByRole('button', { name: /gold image access/i }),
+      fireEvent.click(screen.getByRole('button', { name: /gold image access/i }));
+      expect(String(container.querySelector('tbody')?.firstChild?.childNodes[2].textContent)).toBe(
+        'Failed'
       );
-      expect(
-        String(
-          container.querySelector('tbody')?.firstChild?.childNodes[2]
-            .textContent,
-        ),
-      ).toBe('Failed');
 
-      fireEvent.click(
-        screen.getByRole('button', { name: /gold image access/i }),
+      fireEvent.click(screen.getByRole('button', { name: /gold image access/i }));
+      expect(String(container.querySelector('tbody')?.firstChild?.childNodes[2].textContent)).toBe(
+        'Granted'
       );
-      expect(
-        String(
-          container.querySelector('tbody')?.firstChild?.childNodes[2]
-            .textContent,
-        ),
-      ).toBe('Granted');
     });
 
     it('by date added', () => {
       const { container } = renderTable(makeAccounts(3));
       fireEvent.click(screen.getByRole('button', { name: /date added/i }));
-      expect(
-        String(
-          container.querySelector('tbody')?.firstChild?.childNodes[3]
-            .textContent,
-        ),
-      ).toBe('Formatted:2024-01-01');
+      expect(String(container.querySelector('tbody')?.firstChild?.childNodes[3].textContent)).toBe(
+        'Formatted:2024-01-01'
+      );
 
       fireEvent.click(screen.getByRole('button', { name: /date added/i }));
-      expect(
-        String(
-          container.querySelector('tbody')?.firstChild?.childNodes[3]
-            .textContent,
-        ),
-      ).toBe('Formatted:2024-01-03');
+      expect(String(container.querySelector('tbody')?.firstChild?.childNodes[3].textContent)).toBe(
+        'Formatted:2024-01-03'
+      );
     });
   });
 });

--- a/src/Components/CloudAccounts/__tests__/CloudAccountsToolbar.test.tsx
+++ b/src/Components/CloudAccounts/__tests__/CloudAccountsToolbar.test.tsx
@@ -7,7 +7,7 @@ import {
   cloudAccountIDFilterData,
   cloudAccountsFilterCategoryData,
   cloudProviderFilterData,
-  goldImageStatusFilterData,
+  goldImageStatusFilterData
 } from '../../../state/cloudAccounts';
 import { CloudProviderShortname } from '../../../types/cloudAccountsTypes';
 
@@ -19,7 +19,7 @@ const renderToolbar = ({
   selectedID = '',
   selectedProviders = [],
   selectedStatuses = [],
-  activeCategory = 'ID',
+  activeCategory = 'ID'
 }: {
   selectedID?: string;
   selectedProviders?: string[];
@@ -32,31 +32,24 @@ const renderToolbar = ({
         [cloudAccountIDFilterData, selectedID],
         [cloudAccountsFilterCategoryData, activeCategory],
         [cloudProviderFilterData, selectedProviders],
-        [goldImageStatusFilterData, selectedStatuses],
+        [goldImageStatusFilterData, selectedStatuses]
       ]}
     >
             
       <CloudAccountsToolbar
-        availableProviders={[
-          CloudProviderShortname.AWS,
-          CloudProviderShortname.GCP,
-        ]}
+        availableProviders={[CloudProviderShortname.AWS, CloudProviderShortname.GCP]}
         availableStatuses={['Granted', 'Failed']}
       />
           
-    </HydrateAtomsTestProvider>,
+    </HydrateAtomsTestProvider>
   );
 
 describe('CloudAccountsToolbar', () => {
   it('renders with ID filter by default', () => {
     renderToolbar();
 
-    expect(
-      screen.getByRole('button', { name: /^cloud account$/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByPlaceholderText(/filter by cloud account id/i),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^cloud account$/i })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/filter by cloud account id/i)).toBeInTheDocument();
   });
 
   it('displays selected ID filter', () => {
@@ -68,20 +61,16 @@ describe('CloudAccountsToolbar', () => {
 
   it('shows clear all button when filters are active', () => {
     renderToolbar({
-      selectedProviders: [CloudProviderShortname.AWS],
+      selectedProviders: [CloudProviderShortname.AWS]
     });
 
-    expect(
-      screen.getByRole('button', { name: /clear all filters/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /clear all filters/i })).toBeInTheDocument();
   });
 
   it('does not show clear all when no filters are active', () => {
     renderToolbar();
 
-    expect(
-      screen.queryByRole('button', { name: /clear all filters/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /clear all filters/i })).not.toBeInTheDocument();
   });
 
   it('removes selected ID when label close button is clicked', () => {
@@ -91,9 +80,7 @@ describe('CloudAccountsToolbar', () => {
 
     const closeButtons = screen
       .getAllByRole('button')
-      .filter((button) =>
-        button.getAttribute('aria-label')?.toLowerCase().includes('close'),
-      );
+      .filter((button) => button.getAttribute('aria-label')?.toLowerCase().includes('close'));
 
     if (closeButtons.length === 0) {
       throw new Error('Expected label close button to exist');
@@ -110,12 +97,8 @@ describe('CloudAccountsToolbar', () => {
     fireEvent.click(screen.getByRole('button', { name: /cloud account/i }));
     fireEvent.click(screen.getByText('Cloud provider'));
 
-    expect(
-      screen.getByRole('button', { name: /filter by cloud provider/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId('cloud-account-id-filter'),
-    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /filter by cloud provider/i })).toBeInTheDocument();
+    expect(screen.queryByTestId('cloud-account-id-filter')).not.toBeInTheDocument();
   });
 
   it('switches to status filter when Gold image access category is selected', () => {
@@ -124,18 +107,14 @@ describe('CloudAccountsToolbar', () => {
     fireEvent.click(screen.getByRole('button', { name: /cloud account/i }));
     fireEvent.click(screen.getByText('Gold image access'));
 
-    expect(
-      screen.getByRole('button', { name: /filter by status|status/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId('cloud-account-id-filter'),
-    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /filter by status|status/i })).toBeInTheDocument();
+    expect(screen.queryByTestId('cloud-account-id-filter')).not.toBeInTheDocument();
   });
 
   it('displays selected provider and status filters', () => {
     renderToolbar({
       selectedProviders: [CloudProviderShortname.AWS],
-      selectedStatuses: ['Granted'],
+      selectedStatuses: ['Granted']
     });
 
     expect(screen.getAllByText('Cloud provider').length).toBeGreaterThan(0);
@@ -147,38 +126,28 @@ describe('CloudAccountsToolbar', () => {
   it('renders status filter when active category is Status on initial render', () => {
     renderToolbar({ activeCategory: 'Status' });
 
-    expect(
-      screen.getByRole('button', { name: /filter by status|status/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /filter by status|status/i })).toBeInTheDocument();
 
-    expect(
-      screen.queryByTestId('cloud-account-id-filter'),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('cloud-account-id-filter')).not.toBeInTheDocument();
 
-    expect(
-      screen.queryByTestId('cloud-account-provider-filter'),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('cloud-account-provider-filter')).not.toBeInTheDocument();
   });
 
   it('renders the CloudAccountsPagination component', () => {
     const { container } = renderToolbar();
 
-    expect(
-      container.querySelector('[data-ouia-component-type="PF6/Pagination"]'),
-    ).not.toBeNull();
+    expect(container.querySelector('[data-ouia-component-type="PF6/Pagination"]')).not.toBeNull();
   });
 
   it('shows clear all button when status filter is active', () => {
     renderToolbar({ selectedStatuses: ['Granted'] });
 
-    expect(
-      screen.getByRole('button', { name: /clear all filters/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /clear all filters/i })).toBeInTheDocument();
   });
 
   it('displays selected provider filters only when provider filters are present', () => {
     renderToolbar({
-      selectedProviders: [CloudProviderShortname.AWS],
+      selectedProviders: [CloudProviderShortname.AWS]
     });
 
     expect(screen.getAllByText('Cloud provider').length).toBeGreaterThan(0);
@@ -188,7 +157,7 @@ describe('CloudAccountsToolbar', () => {
 
   it('displays selected status filters only when status filters are present', () => {
     renderToolbar({
-      selectedStatuses: ['Granted'],
+      selectedStatuses: ['Granted']
     });
 
     expect(screen.getAllByText('Gold image access').length).toBeGreaterThan(0);
@@ -211,9 +180,7 @@ describe('CloudAccountsToolbar', () => {
     fireEvent.click(screen.getByRole('button', { name: /cloud account/i }));
     fireEvent.click(screen.getByText('Gold image access'));
 
-    expect(
-      screen.getByRole('button', { name: /^gold image access$/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^gold image access$/i })).toBeInTheDocument();
   });
 
   it('renders all filter category options in the dropdown when opened', () => {

--- a/src/Components/CloudAccounts/__tests__/CloudaccountsPagination.test.tsx
+++ b/src/Components/CloudAccounts/__tests__/CloudaccountsPagination.test.tsx
@@ -6,13 +6,11 @@ import { CloudAccountsPagination } from '../CloudAccountsPagination';
 import { CloudAccountsPaginationData } from '../../../state/cloudAccounts';
 
 const CloudAccountsPaginationWithState = ({
-  init,
+  init
 }: {
   init: { page: number; perPage: number; itemCount: number };
 }) => (
-  <HydrateAtomsTestProvider
-    initialValues={[[CloudAccountsPaginationData, init]]}
-  >
+  <HydrateAtomsTestProvider initialValues={[[CloudAccountsPaginationData, init]]}>
     <CloudAccountsPagination />
   </HydrateAtomsTestProvider>
 );
@@ -20,32 +18,26 @@ const CloudAccountsPaginationWithState = ({
 describe('Cloud Accounts Pagination', () => {
   it('renders', () => {
     const { container } = renderWithRouter(<CloudAccountsPagination />);
-    expect(
-      container.querySelector('.pf-v6-c-pagination__total-items')?.textContent,
-    ).toContain('0 - 0');
+    expect(container.querySelector('.pf-v6-c-pagination__total-items')?.textContent).toContain(
+      '0 - 0'
+    );
   });
   it('goes to the next page', async () => {
     const { container } = renderWithRouter(
-      <CloudAccountsPaginationWithState
-        init={{ page: 1, perPage: 10, itemCount: 150 }}
-      />,
+      <CloudAccountsPaginationWithState init={{ page: 1, perPage: 10, itemCount: 150 }} />
     );
-    const nextButton = container.querySelector(
-      '[aria-label="Go to next page"]',
-    );
+    const nextButton = container.querySelector('[aria-label="Go to next page"]');
     if (!nextButton) throw new Error('Next page button not found');
     await waitFor(() =>
-      expect(
-        container.querySelector('.pf-v6-c-pagination__total-items')
-          ?.textContent,
-      ).toContain('1 - 10 of 150'),
+      expect(container.querySelector('.pf-v6-c-pagination__total-items')?.textContent).toContain(
+        '1 - 10 of 150'
+      )
     );
     fireEvent.click(nextButton);
     await waitFor(() =>
-      expect(
-        container.querySelector('.pf-v6-c-pagination__total-items')
-          ?.textContent,
-      ).toContain('11 - 20'),
+      expect(container.querySelector('.pf-v6-c-pagination__total-items')?.textContent).toContain(
+        '11 - 20'
+      )
     );
   });
 });

--- a/src/Components/CloudAccounts/__tests__/GoldImageAccessFilter.test.tsx
+++ b/src/Components/CloudAccounts/__tests__/GoldImageAccessFilter.test.tsx
@@ -16,11 +16,7 @@ const GoldImageAccessFilterWithState = ({ init = [] }: { init?: string[] }) => (
   </HydrateAtomsTestProvider>
 );
 
-const GoldImageAccessFilterWithStateObserver = ({
-  init = [],
-}: {
-  init?: string[];
-}) => {
+const GoldImageAccessFilterWithStateObserver = ({ init = [] }: { init?: string[] }) => {
   const StateObserver = () => {
     const selectedStatuses = useAtomValue(goldImageStatusFilterData);
 
@@ -33,9 +29,7 @@ const GoldImageAccessFilterWithStateObserver = ({
   };
 
   return (
-    <HydrateAtomsTestProvider
-      initialValues={[[goldImageStatusFilterData, init]]}
-    >
+    <HydrateAtomsTestProvider initialValues={[[goldImageStatusFilterData, init]]}>
             
       <GoldImageAccessFilter availableStatuses={availableStatuses} />
             
@@ -49,9 +43,7 @@ describe('GoldImageAccessFilter', () => {
   it('renders default label when no statuses are selected', () => {
     renderWithRouter(<GoldImageAccessFilterWithState />);
 
-    expect(
-      screen.getByRole('button', { name: 'Filter by status' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Filter by status' })).toBeInTheDocument();
   });
 
   it('renders available status options when opened', async () => {
@@ -78,19 +70,13 @@ describe('GoldImageAccessFilter', () => {
     fireEvent.click(screen.getByText('available'));
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: 'Status' }),
-      ).toBeInTheDocument();
-      expect(screen.getByTestId('selected-statuses')).toHaveTextContent(
-        '["available"]',
-      );
+      expect(screen.getByRole('button', { name: 'Status' })).toBeInTheDocument();
+      expect(screen.getByTestId('selected-statuses')).toHaveTextContent('["available"]');
     });
   });
 
   it('does not remove a selected status when it is selected again from the menu', async () => {
-    renderWithRouter(
-      <GoldImageAccessFilterWithStateObserver init={['available']} />,
-    );
+    renderWithRouter(<GoldImageAccessFilterWithStateObserver init={['available']} />);
 
     expect(screen.getByRole('button', { name: 'Status' })).toBeInTheDocument();
 
@@ -103,21 +89,15 @@ describe('GoldImageAccessFilter', () => {
     fireEvent.click(screen.getByText('available'));
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: 'Status' }),
-      ).toBeInTheDocument();
-      expect(screen.getByTestId('selected-statuses')).toHaveTextContent(
-        '["available"]',
-      );
+      expect(screen.getByRole('button', { name: 'Status' })).toBeInTheDocument();
+      expect(screen.getByTestId('selected-statuses')).toHaveTextContent('["available"]');
     });
   });
 
   it('supports multiple selected statuses by reopening the menu', async () => {
     renderWithRouter(<GoldImageAccessFilterWithStateObserver />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: /filter by status|status/i }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: /filter by status|status/i }));
 
     await waitFor(() => {
       expect(screen.getByText('available')).toBeInTheDocument();
@@ -126,12 +106,8 @@ describe('GoldImageAccessFilter', () => {
     fireEvent.click(screen.getByText('available'));
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: 'Status' }),
-      ).toBeInTheDocument();
-      expect(screen.getByTestId('selected-statuses')).toHaveTextContent(
-        '["available"]',
-      );
+      expect(screen.getByRole('button', { name: 'Status' })).toBeInTheDocument();
+      expect(screen.getByTestId('selected-statuses')).toHaveTextContent('["available"]');
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Status' }));
@@ -143,19 +119,13 @@ describe('GoldImageAccessFilter', () => {
     fireEvent.click(screen.getByText('pending'));
 
     await waitFor(() => {
-      expect(screen.getByTestId('selected-statuses')).toHaveTextContent(
-        '["available","pending"]',
-      );
-      expect(
-        screen.getByRole('button', { name: 'Status' }),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId('selected-statuses')).toHaveTextContent('["available","pending"]');
+      expect(screen.getByRole('button', { name: 'Status' })).toBeInTheDocument();
     });
   });
 
   it('shows Status label when initialized with selected statuses', () => {
-    renderWithRouter(
-      <GoldImageAccessFilterWithState init={['available', 'pending']} />,
-    );
+    renderWithRouter(<GoldImageAccessFilterWithState init={['available', 'pending']} />);
 
     expect(screen.getByRole('button', { name: 'Status' })).toBeInTheDocument();
   });
@@ -163,9 +133,7 @@ describe('GoldImageAccessFilter', () => {
   it('closes the menu after selecting a status', async () => {
     renderWithRouter(<GoldImageAccessFilterWithStateObserver />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: /filter by status|status/i }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: /filter by status|status/i }));
 
     await waitFor(() => {
       expect(screen.getByText('available')).toBeInTheDocument();

--- a/src/Components/CloudAccounts/__tests__/NoCloudAccounts.test.tsx
+++ b/src/Components/CloudAccounts/__tests__/NoCloudAccounts.test.tsx
@@ -5,14 +5,14 @@ import { MemoryRouter } from 'react-router-dom';
 
 jest.mock('@patternfly/react-icons/dist/esm/icons/cubes-icon', () => ({
   __esModule: true,
-  default: () => <div data-testid="mock-cubes-icon" />,
+  default: () => <div data-testid="mock-cubes-icon" />
 }));
 describe('NoCloudAccounts', () => {
   const renderWithRouter = () =>
     render(
       <MemoryRouter>
         <NoCloudAccounts />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
   it('renders the empty state title', () => {
@@ -25,7 +25,7 @@ describe('NoCloudAccounts', () => {
     renderWithRouter();
 
     const button = screen.getByRole('button', {
-      name: /view documentation/i,
+      name: /view documentation/i
     });
 
     expect(button).toBeInTheDocument();
@@ -36,7 +36,7 @@ describe('NoCloudAccounts', () => {
     renderWithRouter();
 
     const link = screen.getByRole('link', {
-      name: /integrations/i,
+      name: /integrations/i
     });
 
     expect(link).toBeInTheDocument();

--- a/src/Components/EmptyState/NoSearchResults.tsx
+++ b/src/Components/EmptyState/NoSearchResults.tsx
@@ -7,9 +7,7 @@ export const NoSearchResults = () => {
 
   return (
     <EmptyState>
-      <EmptyStateBody>
-        No results found. Try adjusting your filters.       
-      </EmptyStateBody>
+      <EmptyStateBody>No results found. Try adjusting your filters.       </EmptyStateBody>
       <Button variant="link" onClick={clearFilters} isInline>
         Clear all filters       
       </Button>

--- a/src/Components/EmptyState/__tests__/NoSearchResults.test.tsx
+++ b/src/Components/EmptyState/__tests__/NoSearchResults.test.tsx
@@ -7,7 +7,7 @@ import {
   CloudAccountsPaginationData,
   cloudAccountIDFilterData,
   cloudProviderFilterData,
-  goldImageStatusFilterData,
+  goldImageStatusFilterData
 } from '../../../state/cloudAccounts';
 import { CloudProviderShortname } from '../../../types/cloudAccountsTypes';
 import { NoSearchResults } from '../NoSearchResults';
@@ -35,7 +35,7 @@ const NoSearchResultsWithState = () => {
         [CloudAccountsPaginationData, { page: 3, perPage: 10, itemCount: 25 }],
         [cloudProviderFilterData, [CloudProviderShortname.AWS]],
         [goldImageStatusFilterData, ['available']],
-        [cloudAccountIDFilterData, 'abc123'],
+        [cloudAccountIDFilterData, 'abc123']
       ]}
     >
       <NoSearchResults />
@@ -49,16 +49,14 @@ describe('NoSearchResults', () => {
     renderWithRouter(<NoSearchResultsWithState />);
 
     expect(
-      screen.getByText(/no results found\. try adjusting your filters\./i),
+      screen.getByText(/no results found\. try adjusting your filters\./i)
     ).toBeInTheDocument();
   });
 
   it('renders the clear all filters button', () => {
     renderWithRouter(<NoSearchResultsWithState />);
 
-    expect(
-      screen.getByRole('button', { name: /clear all filters/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /clear all filters/i })).toBeInTheDocument();
   });
 
   it('clears filters and resets pagination when clear all filters is clicked', () => {
@@ -70,7 +68,7 @@ describe('NoSearchResults', () => {
     expect(screen.getByTestId('statuses')).toHaveTextContent('[]');
     expect(screen.getByTestId('account-id')).toHaveTextContent('""');
     expect(screen.getByTestId('pagination')).toHaveTextContent(
-      '{"page":1,"perPage":10,"itemCount":25}',
+      '{"page":1,"perPage":10,"itemCount":25}'
     );
   });
 });

--- a/src/Components/GoldImages/CloudProviderFilterList.tsx
+++ b/src/Components/GoldImages/CloudProviderFilterList.tsx
@@ -5,11 +5,9 @@ import { useQueryParamInformedAtom } from '../../hooks/util/useQueryParam';
 import { CloudProviderName } from '../../hooks/api/useGoldImages';
 
 export const CloudProviderFilterList = () => {
-  const [cloudProviderFilter, setCloudProviderFilter] =
-    useQueryParamInformedAtom<CloudProviderName[]>(
-      cloudProviderFilterData,
-      'cloudProvider',
-    );
+  const [cloudProviderFilter, setCloudProviderFilter] = useQueryParamInformedAtom<
+    CloudProviderName[]
+  >(cloudProviderFilterData, 'cloudProvider');
 
   return (
     <>
@@ -19,9 +17,7 @@ export const CloudProviderFilterList = () => {
             key={cloudProvider}
             onClose={() => {
               setCloudProviderFilter(
-                cloudProviderFilter.filter(
-                  (existing) => cloudProvider != existing,
-                ),
+                cloudProviderFilter.filter((existing) => cloudProvider != existing)
               );
             }}
           >

--- a/src/Components/GoldImages/CloudProviderFilterSelect.tsx
+++ b/src/Components/GoldImages/CloudProviderFilterSelect.tsx
@@ -4,7 +4,7 @@ import {
   MenuToggleElement,
   Select,
   SelectList,
-  SelectOption,
+  SelectOption
 } from '@patternfly/react-core';
 import React, { Ref, useState } from 'react';
 import { cloudProviderFilterData } from '../../state/goldImages';
@@ -15,12 +15,12 @@ interface CloudProviderFilterSelectProps {
   cloudProviders: string[];
 }
 
-export const CloudProviderFilterSelect = ({
-  cloudProviders,
-}: CloudProviderFilterSelectProps) => {
+export const CloudProviderFilterSelect = ({ cloudProviders }: CloudProviderFilterSelectProps) => {
   const [isFilterExpanded, setIsFilterExpanded] = useState(false);
-  const [cloudProviderFilter, setCloudProviderFilter] =
-    useQueryParamInformedAtom(cloudProviderFilterData, 'cloudProvider');
+  const [cloudProviderFilter, setCloudProviderFilter] = useQueryParamInformedAtom(
+    cloudProviderFilterData,
+    'cloudProvider'
+  );
 
   return (
     <Select
@@ -32,12 +32,9 @@ export const CloudProviderFilterSelect = ({
             onClick={() => setIsFilterExpanded(!isFilterExpanded)}
             isExpanded={isFilterExpanded}
             splitButtonItems={[
-              <MenuToggleAction
-                key="label"
-                onClick={() => setIsFilterExpanded(!isFilterExpanded)}
-              >
+              <MenuToggleAction key="label" onClick={() => setIsFilterExpanded(!isFilterExpanded)}>
                 Cloud Provider
-              </MenuToggleAction>,
+              </MenuToggleAction>
             ]}
           >
             {'Filter by cloud provider'}
@@ -47,10 +44,7 @@ export const CloudProviderFilterSelect = ({
       selected={cloudProviderFilter}
       onSelect={(_event, value) => {
         if (!cloudProviderFilter.includes(value as CloudProviderName)) {
-          setCloudProviderFilter([
-            ...cloudProviderFilter,
-            value as CloudProviderName,
-          ]);
+          setCloudProviderFilter([...cloudProviderFilter, value as CloudProviderName]);
         }
         setIsFilterExpanded(false);
       }}

--- a/src/Components/GoldImages/GoldImagesPagination.tsx
+++ b/src/Components/GoldImages/GoldImagesPagination.tsx
@@ -3,7 +3,5 @@ import { goldImagePaginationData } from '../../state/goldImages';
 import { PaginationBase } from '../shared/PaginationBase';
 
 export const GoldImagesPagination = ({ isCompact = false }) => {
-  return (
-    <PaginationBase atom={goldImagePaginationData} isCompact={isCompact} />
-  );
+  return <PaginationBase atom={goldImagePaginationData} isCompact={isCompact} />;
 };

--- a/src/Components/GoldImages/GoldImagesTable.tsx
+++ b/src/Components/GoldImages/GoldImagesTable.tsx
@@ -1,27 +1,13 @@
 import React, { useEffect } from 'react';
-import {
-  CloudProviderName,
-  GoldImagesResponse,
-} from '../../hooks/api/useGoldImages';
-import {
-  SortByDirection,
-  Table,
-  Tbody,
-  Td,
-  Th,
-  Thead,
-  Tr,
-} from '@patternfly/react-table';
+import { CloudProviderName, GoldImagesResponse } from '../../hooks/api/useGoldImages';
+import { SortByDirection, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { Content } from '@patternfly/react-core';
 import { useTableSort } from '../../hooks/util/tables/useTableSort';
 import { useAtomValue } from 'jotai';
-import {
-  cloudProviderFilterData,
-  goldImagePaginationData,
-} from '../../state/goldImages';
+import { cloudProviderFilterData, goldImagePaginationData } from '../../state/goldImages';
 import {
   generateQueryParamsForData,
-  useQueryParamInformedAtom,
+  useQueryParamInformedAtom
 } from '../../hooks/util/useQueryParam';
 import { hasPaginationError } from '../../utils/errors';
 import { PaginationError } from '../shared/PaginationError';
@@ -36,7 +22,7 @@ interface GoldImagesProps {
 export const GoldImagesTable = ({ goldImages }: GoldImagesProps) => {
   const [pageOptions, setGoldImagePagination] = useQueryParamInformedAtom(
     goldImagePaginationData,
-    'pagination',
+    'pagination'
   );
   const cloudProviderFilter = useAtomValue(cloudProviderFilterData);
 
@@ -46,46 +32,37 @@ export const GoldImagesTable = ({ goldImages }: GoldImagesProps) => {
     cloudProviderFilter.length == 0
       ? Object.values(goldImages)
       : Object.values(goldImages).filter((cloudProvider) =>
-          cloudProviderFilter.includes(cloudProvider.provider),
+          cloudProviderFilter.includes(cloudProvider.provider)
         );
 
-  const { sorted, getSortParams } = useTableSort(
-    filteredGoldImages,
-    'goldImages',
-    {
-      rowTranslator: (hyperscaler) => [hyperscaler.provider],
-      initialSort: {
-        dir: SortByDirection.asc,
-        index: 0,
-      },
-    },
-  );
+  const { sorted, getSortParams } = useTableSort(filteredGoldImages, 'goldImages', {
+    rowTranslator: (hyperscaler) => [hyperscaler.provider],
+    initialSort: {
+      dir: SortByDirection.asc,
+      index: 0
+    }
+  });
 
   const paginatedGoldImage = sorted.slice(
     (pageOptions.page - 1) * pageOptions.perPage,
-    pageOptions.page * pageOptions.perPage,
+    pageOptions.page * pageOptions.perPage
   );
 
   const goldImagesProviderToCloudAccountShortName = {
     [CloudProviderName.AWS]: CloudProviderShortname.AWS,
     [CloudProviderName.GCP]: CloudProviderShortname.GCP,
-    [CloudProviderName.AZURE]: CloudProviderShortname.AZURE,
+    [CloudProviderName.AZURE]: CloudProviderShortname.AZURE
   };
 
   useEffect(() => {
     setGoldImagePagination({
       ...pageOptions,
-      itemCount: filteredGoldImages.length,
+      itemCount: filteredGoldImages.length
     });
   }, [cloudProviderFilter, filteredGoldImages.length]);
 
   if (onInvalidPage) {
-    return (
-      <PaginationError
-        pagination={pageOptions}
-        setPagination={setGoldImagePagination}
-      />
-    );
+    return <PaginationError pagination={pageOptions} setPagination={setGoldImagePagination} />;
   }
 
   return (
@@ -112,12 +89,8 @@ export const GoldImagesTable = ({ goldImages }: GoldImagesProps) => {
               <Td modifier="fitContent">
                 <Link
                   to={`../${Paths.CloudAccounts}?${generateQueryParamsForData(
-                    [
-                      goldImagesProviderToCloudAccountShortName[
-                        hyperscaler.provider
-                      ],
-                    ],
-                    'shortName',
+                    [goldImagesProviderToCloudAccountShortName[hyperscaler.provider]],
+                    'shortName'
                   ).toString()}`}
                 >
                     View cloud accounts

--- a/src/Components/GoldImages/GoldImagesToolbar.tsx
+++ b/src/Components/GoldImages/GoldImagesToolbar.tsx
@@ -10,9 +10,7 @@ interface GoldImagesFilterBarProps {
 }
 
 export const GoldImagesToolbar = ({ goldImages }: GoldImagesFilterBarProps) => {
-  const cloudProviders = Object.values(goldImages).map(
-    (goldImage) => goldImage.provider,
-  );
+  const cloudProviders = Object.values(goldImages).map((goldImage) => goldImage.provider);
 
   return (
     <>

--- a/src/Components/GoldImages/__tests__/CloudProviderFilterList.test.tsx
+++ b/src/Components/GoldImages/__tests__/CloudProviderFilterList.test.tsx
@@ -6,11 +6,7 @@ import { CloudProviderFilterList } from '../CloudProviderFilterList';
 import { cloudProviderFilterData } from '../../../state/goldImages';
 import { CloudProviderName } from '../../../hooks/api/useGoldImages';
 
-const CloudProviderFilterListWithState = ({
-  init,
-}: {
-  init: CloudProviderName[];
-}) => (
+const CloudProviderFilterListWithState = ({ init }: { init: CloudProviderName[] }) => (
   <HydrateAtomsTestProvider initialValues={[[cloudProviderFilterData, init]]}>
     <CloudProviderFilterList />
   </HydrateAtomsTestProvider>
@@ -22,9 +18,7 @@ describe('Cloud provider filter list', () => {
   });
 
   it('renderWithRouters when filters are set', () => {
-    renderWithRouter(
-      <CloudProviderFilterListWithState init={[CloudProviderName.AWS]} />,
-    );
+    renderWithRouter(<CloudProviderFilterListWithState init={[CloudProviderName.AWS]} />);
 
     expect(screen.queryByText('Cloud provider')).toBeInTheDocument();
     expect(screen.queryByText('AWS')).toBeInTheDocument();
@@ -32,9 +26,7 @@ describe('Cloud provider filter list', () => {
 
   it('only renderWithRouters selected filters', () => {
     renderWithRouter(
-      <CloudProviderFilterListWithState
-        init={[CloudProviderName.AWS, CloudProviderName.GCP]}
-      />,
+      <CloudProviderFilterListWithState init={[CloudProviderName.AWS, CloudProviderName.GCP]} />
     );
 
     expect(screen.queryByText('AWS')).toBeInTheDocument();
@@ -50,17 +42,13 @@ describe('Cloud provider filter list', () => {
 
   it('removes filter when "x" is clicked', () => {
     const { container } = renderWithRouter(
-      <CloudProviderFilterListWithState
-        init={[CloudProviderName.AWS, CloudProviderName.GCP]}
-      />,
+      <CloudProviderFilterListWithState init={[CloudProviderName.AWS, CloudProviderName.GCP]} />
     );
 
     expect(screen.queryByText('AWS')).toBeInTheDocument();
     expect(screen.queryByText('Google Compute Engine')).toBeInTheDocument();
 
-    const closeButton = container.querySelector(
-      '[aria-label="Close Google Compute Engine"]',
-    );
+    const closeButton = container.querySelector('[aria-label="Close Google Compute Engine"]');
 
     if (!closeButton) {
       throw new Error('Close button not found');
@@ -74,16 +62,14 @@ describe('Cloud provider filter list', () => {
 
   it('clears all filters when "Clear filters" is clicked', () => {
     renderWithRouter(
-      <CloudProviderFilterListWithState
-        init={[CloudProviderName.AWS, CloudProviderName.GCP]}
-      />,
+      <CloudProviderFilterListWithState init={[CloudProviderName.AWS, CloudProviderName.GCP]} />
     );
 
     expect(screen.getByText('AWS')).toBeInTheDocument();
     expect(screen.getByText('Google Compute Engine')).toBeInTheDocument();
 
     const clearAllButton = screen.getByRole('button', {
-      name: /clear filters/i,
+      name: /clear filters/i
     });
 
     fireEvent.click(clearAllButton);
@@ -91,8 +77,6 @@ describe('Cloud provider filter list', () => {
     expect(screen.queryByText('AWS')).not.toBeInTheDocument();
     expect(screen.queryByText('Google Compute Engine')).not.toBeInTheDocument();
 
-    expect(
-      screen.queryByRole('button', { name: /clear filters/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /clear filters/i })).not.toBeInTheDocument();
   });
 });

--- a/src/Components/GoldImages/__tests__/CloudProviderFilterSelect.test.tsx
+++ b/src/Components/GoldImages/__tests__/CloudProviderFilterSelect.test.tsx
@@ -7,9 +7,7 @@ import { renderWithRouter } from '../../../utils/testing/customRender';
 
 const CloudProviderFilterSelectWithState = ({ init }: { init: string[] }) => (
   <HydrateAtomsTestProvider initialValues={[[cloudProviderFilterData, init]]}>
-    <CloudProviderFilterSelect
-      cloudProviders={['AWS', 'Google Cloud Engine', 'Microsoft Azure']}
-    />
+    <CloudProviderFilterSelect cloudProviders={['AWS', 'Google Cloud Engine', 'Microsoft Azure']} />
   </HydrateAtomsTestProvider>
 );
 
@@ -21,9 +19,7 @@ describe('Cloud provider filter select', () => {
   });
 
   it('renders the options', async () => {
-    const { queryByText } = renderWithRouter(
-      <CloudProviderFilterSelectWithState init={[]} />,
-    );
+    const { queryByText } = renderWithRouter(<CloudProviderFilterSelectWithState init={[]} />);
 
     expect(screen.queryByText('AWS')).not.toBeInTheDocument();
     expect(screen.queryByText('Google Cloud Engine')).not.toBeInTheDocument();
@@ -38,18 +34,12 @@ describe('Cloud provider filter select', () => {
     fireEvent.click(expandButton);
 
     await waitFor(() => expect(screen.queryByText('AWS')).toBeInTheDocument());
-    await waitFor(() =>
-      expect(screen.queryByText('Google Cloud Engine')).toBeInTheDocument(),
-    );
-    await waitFor(() =>
-      expect(screen.queryByText('Microsoft Azure')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.queryByText('Google Cloud Engine')).toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText('Microsoft Azure')).toBeInTheDocument());
   });
 
   it('can select an option', async () => {
-    const { queryByText } = renderWithRouter(
-      <CloudProviderFilterSelectWithState init={[]} />,
-    );
+    const { queryByText } = renderWithRouter(<CloudProviderFilterSelectWithState init={[]} />);
 
     const expandButton = queryByText('Filter by cloud provider')?.parentElement;
 
@@ -59,9 +49,7 @@ describe('Cloud provider filter select', () => {
 
     fireEvent.click(expandButton);
 
-    await waitFor(() =>
-      expect(screen.queryByText('AWS')?.nextSibling).not.toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.queryByText('AWS')?.nextSibling).not.toBeInTheDocument());
 
     const selectAwsButton = queryByText('AWS')?.parentElement?.parentElement;
 
@@ -73,16 +61,12 @@ describe('Cloud provider filter select', () => {
     fireEvent.click(expandButton);
 
     await waitFor(() =>
-      expect(screen.queryByText('AWS')?.nextSibling).toHaveClass(
-        'pf-v6-c-menu__item-select-icon',
-      ),
+      expect(screen.queryByText('AWS')?.nextSibling).toHaveClass('pf-v6-c-menu__item-select-icon')
     );
   });
 
   it('can expand with label', async () => {
-    const { queryByText } = renderWithRouter(
-      <CloudProviderFilterSelectWithState init={[]} />,
-    );
+    const { queryByText } = renderWithRouter(<CloudProviderFilterSelectWithState init={[]} />);
 
     const expandButton = queryByText('Cloud Provider');
 
@@ -96,14 +80,12 @@ describe('Cloud provider filter select', () => {
 
     fireEvent.click(expandButton);
 
-    await waitFor(() =>
-      expect(screen.queryByText('AWS')).not.toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.queryByText('AWS')).not.toBeInTheDocument());
   });
 
   it('closes when clicked outside of', async () => {
     const { container, queryByText } = renderWithRouter(
-      <CloudProviderFilterSelectWithState init={[]} />,
+      <CloudProviderFilterSelectWithState init={[]} />
     );
 
     const expandButton = queryByText('Filter by cloud provider')?.parentElement;
@@ -120,8 +102,6 @@ describe('Cloud provider filter select', () => {
 
     fireEvent.click(clickOutside);
 
-    await waitFor(() =>
-      expect(screen.queryByText('AWS')).not.toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.queryByText('AWS')).not.toBeInTheDocument());
   });
 });

--- a/src/Components/GoldImages/__tests__/GoldImagesPagination.test.tsx
+++ b/src/Components/GoldImages/__tests__/GoldImagesPagination.test.tsx
@@ -6,7 +6,7 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import { renderWithRouter } from '../../../utils/testing/customRender';
 
 const GoldImagesPaginationWithState = ({
-  init,
+  init
 }: {
   init: { page: number; perPage: number; itemCount: number };
 }) => (
@@ -20,21 +20,16 @@ describe('Gold Images Pagination', () => {
     const { container } = renderWithRouter(<GoldImagesPagination />);
 
     expect(
-      container.querySelector('.pf-v6-c-pagination__total-items')?.firstChild
-        ?.textContent,
+      container.querySelector('.pf-v6-c-pagination__total-items')?.firstChild?.textContent
     ).toBe('0 - 0');
   });
 
   it('can go to the next page', async () => {
     const { container } = renderWithRouter(
-      <GoldImagesPaginationWithState
-        init={{ page: 1, perPage: 10, itemCount: 123 }}
-      />,
+      <GoldImagesPaginationWithState init={{ page: 1, perPage: 10, itemCount: 123 }} />
     );
 
-    const nextButton = container.querySelector(
-      '[aria-label="Go to next page"]',
-    );
+    const nextButton = container.querySelector('[aria-label="Go to next page"]');
 
     if (!nextButton) {
       throw new Error('Next page button not found');
@@ -42,31 +37,25 @@ describe('Gold Images Pagination', () => {
 
     await waitFor(() =>
       expect(
-        container.querySelector('.pf-v6-c-pagination__total-items')?.firstChild
-          ?.textContent,
-      ).toBe('1 - 10'),
+        container.querySelector('.pf-v6-c-pagination__total-items')?.firstChild?.textContent
+      ).toBe('1 - 10')
     );
 
     fireEvent.click(nextButton);
 
     await waitFor(() =>
       expect(
-        container.querySelector('.pf-v6-c-pagination__total-items')?.firstChild
-          ?.textContent,
-      ).toBe('11 - 20'),
+        container.querySelector('.pf-v6-c-pagination__total-items')?.firstChild?.textContent
+      ).toBe('11 - 20')
     );
   });
 
   it('can go back a page', async () => {
     const { container } = renderWithRouter(
-      <GoldImagesPaginationWithState
-        init={{ page: 2, perPage: 10, itemCount: 123 }}
-      />,
+      <GoldImagesPaginationWithState init={{ page: 2, perPage: 10, itemCount: 123 }} />
     );
 
-    const previousButton = container.querySelector(
-      '[aria-label="Go to previous page"]',
-    );
+    const previousButton = container.querySelector('[aria-label="Go to previous page"]');
 
     if (!previousButton) {
       throw new Error('Next page button not found');
@@ -74,30 +63,26 @@ describe('Gold Images Pagination', () => {
 
     await waitFor(() =>
       expect(
-        container.querySelector('.pf-v6-c-pagination__total-items')?.firstChild
-          ?.textContent,
-      ).toBe('11 - 20'),
+        container.querySelector('.pf-v6-c-pagination__total-items')?.firstChild?.textContent
+      ).toBe('11 - 20')
     );
 
     fireEvent.click(previousButton);
 
     await waitFor(() =>
       expect(
-        container.querySelector('.pf-v6-c-pagination__total-items')?.firstChild
-          ?.textContent,
-      ).toBe('1 - 10'),
+        container.querySelector('.pf-v6-c-pagination__total-items')?.firstChild?.textContent
+      ).toBe('1 - 10')
     );
   });
 
   it('can change page size', async () => {
     const { container, queryByText } = renderWithRouter(
-      <GoldImagesPaginationWithState
-        init={{ page: 1, perPage: 10, itemCount: 123 }}
-      />,
+      <GoldImagesPaginationWithState init={{ page: 1, perPage: 10, itemCount: 123 }} />
     );
 
     const expandPageSelectionButton = container.querySelector(
-      '[data-ouia-component-type="PF6/MenuToggle"]',
+      '[data-ouia-component-type="PF6/MenuToggle"]'
     );
 
     if (!expandPageSelectionButton) {
@@ -106,15 +91,14 @@ describe('Gold Images Pagination', () => {
 
     await waitFor(() =>
       expect(
-        container.querySelector('.pf-v6-c-pagination__total-items')?.firstChild
-          ?.textContent,
-      ).toBe('1 - 10'),
+        container.querySelector('.pf-v6-c-pagination__total-items')?.firstChild?.textContent
+      ).toBe('1 - 10')
     );
 
     fireEvent.click(expandPageSelectionButton);
 
     const twentyPerPageSelectionButton = await waitFor(
-      () => queryByText('20 per page')?.parentElement?.parentElement,
+      () => queryByText('20 per page')?.parentElement?.parentElement
     );
 
     if (!twentyPerPageSelectionButton) {
@@ -125,9 +109,8 @@ describe('Gold Images Pagination', () => {
 
     await waitFor(() =>
       expect(
-        container.querySelector('.pf-v6-c-pagination__total-items')?.firstChild
-          ?.textContent,
-      ).toBe('1 - 20'),
+        container.querySelector('.pf-v6-c-pagination__total-items')?.firstChild?.textContent
+      ).toBe('1 - 20')
     );
   });
 });

--- a/src/Components/GoldImages/__tests__/GoldImagesTable.test.tsx
+++ b/src/Components/GoldImages/__tests__/GoldImagesTable.test.tsx
@@ -1,26 +1,14 @@
 import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithRouter } from '../../../utils/testing/customRender';
-import {
-  CloudProviderName,
-  GoldImagesResponse,
-} from '../../../hooks/api/useGoldImages';
+import { CloudProviderName, GoldImagesResponse } from '../../../hooks/api/useGoldImages';
 import { GoldImagesTable } from '../GoldImagesTable';
 import { HydrateAtomsTestProvider } from '../../util/testing/HydrateAtomsTestProvider';
-import {
-  cloudProviderFilterData,
-  goldImagePaginationData,
-} from '../../../state/goldImages';
+import { cloudProviderFilterData, goldImagePaginationData } from '../../../state/goldImages';
 import { Paths } from '../../../utils/routing';
 
-const goldImageTestData: (amount: number) => GoldImagesResponse = (
-  amount: number,
-) => {
-  const providers = [
-    CloudProviderName.AWS,
-    CloudProviderName.GCP,
-    CloudProviderName.AZURE,
-  ];
+const goldImageTestData: (amount: number) => GoldImagesResponse = (amount: number) => {
+  const providers = [CloudProviderName.AWS, CloudProviderName.GCP, CloudProviderName.AZURE];
 
   const data: GoldImagesResponse = {};
 
@@ -31,9 +19,9 @@ const goldImageTestData: (amount: number) => GoldImagesResponse = (
       goldImages: [
         {
           name: `Test ${i}`,
-          description: `Test description ${i}`,
-        },
-      ],
+          description: `Test description ${i}`
+        }
+      ]
     };
   }
 
@@ -42,9 +30,7 @@ const goldImageTestData: (amount: number) => GoldImagesResponse = (
 
 describe('Gold images table', () => {
   it('renders', () => {
-    const { container } = renderWithRouter(
-      <GoldImagesTable goldImages={goldImageTestData(3)} />,
-    );
+    const { container } = renderWithRouter(<GoldImagesTable goldImages={goldImageTestData(3)} />);
 
     expect(container.querySelector('table')).toBeInTheDocument();
   });
@@ -52,12 +38,10 @@ describe('Gold images table', () => {
   it('sorts', async () => {
     const goldImageData = goldImageTestData(3);
     const sortedGoldImageData = Object.values(goldImageData).sort((a, b) =>
-      a.provider.localeCompare(b.provider),
+      a.provider.localeCompare(b.provider)
     );
 
-    const { container } = renderWithRouter(
-      <GoldImagesTable goldImages={goldImageData} />,
-    );
+    const { container } = renderWithRouter(<GoldImagesTable goldImages={goldImageData} />);
 
     const sortButton = container.querySelector('button');
 
@@ -69,25 +53,21 @@ describe('Gold images table', () => {
 
     await waitFor(() =>
       expect(
-        container.querySelector('tbody')?.firstChild?.firstChild?.firstChild
-          ?.textContent,
-      ).toBe(sortedGoldImageData[sortedGoldImageData.length - 1].provider),
+        container.querySelector('tbody')?.firstChild?.firstChild?.firstChild?.textContent
+      ).toBe(sortedGoldImageData[sortedGoldImageData.length - 1].provider)
     );
 
     fireEvent.click(sortButton);
 
     await waitFor(() =>
       expect(
-        container.querySelector('tbody')?.firstChild?.firstChild?.firstChild
-          ?.textContent,
-      ).toBe(sortedGoldImageData[0].provider),
+        container.querySelector('tbody')?.firstChild?.firstChild?.firstChild?.textContent
+      ).toBe(sortedGoldImageData[0].provider)
     );
   });
 
   it('applies pagination', () => {
-    const { container } = renderWithRouter(
-      <GoldImagesTable goldImages={goldImageTestData(12)} />,
-    );
+    const { container } = renderWithRouter(<GoldImagesTable goldImages={goldImageTestData(12)} />);
 
     expect(container.querySelector('tbody')?.childNodes.length).toBe(10);
   });
@@ -97,28 +77,23 @@ describe('Gold images table', () => {
 
     const { container } = renderWithRouter(
       <HydrateAtomsTestProvider
-        initialValues={[
-          [cloudProviderFilterData, [Object.values(goldImageData)[0].provider]],
-        ]}
+        initialValues={[[cloudProviderFilterData, [Object.values(goldImageData)[0].provider]]]}
       >
         <GoldImagesTable goldImages={goldImageData} />
-      </HydrateAtomsTestProvider>,
+      </HydrateAtomsTestProvider>
     );
 
     expect(container.querySelector('tbody')?.childNodes.length).toBe(1);
-    expect(
-      container.querySelector('tbody')?.firstChild?.firstChild?.firstChild
-        ?.textContent,
-    ).toBe(Object.values(goldImageData)[0].provider);
+    expect(container.querySelector('tbody')?.firstChild?.firstChild?.firstChild?.textContent).toBe(
+      Object.values(goldImageData)[0].provider
+    );
   });
 
   it('does not render pagination error when on valid page', () => {
-    const { container } = renderWithRouter(
-      <GoldImagesTable goldImages={goldImageTestData(25)} />,
-    );
+    const { container } = renderWithRouter(<GoldImagesTable goldImages={goldImageTestData(25)} />);
 
     expect(container.querySelector('table')?.textContent).not.toMatch(
-      /No results for current page/i,
+      /No results for current page/i
     );
   });
 
@@ -127,12 +102,10 @@ describe('Gold images table', () => {
 
     const { container } = renderWithRouter(
       <HydrateAtomsTestProvider
-        initialValues={[
-          [goldImagePaginationData, { page: 10, perPage: 10, itemCount: 5 }],
-        ]}
+        initialValues={[[goldImagePaginationData, { page: 10, perPage: 10, itemCount: 5 }]]}
       >
         <GoldImagesTable goldImages={goldImageData} />
-      </HydrateAtomsTestProvider>,
+      </HydrateAtomsTestProvider>
     );
 
     expect(container.textContent).toMatch(/No results for current page/i);
@@ -144,12 +117,10 @@ describe('Gold images table', () => {
 
     const { container } = renderWithRouter(
       <HydrateAtomsTestProvider
-        initialValues={[
-          [goldImagePaginationData, { page: 10, perPage: 10, itemCount: 5 }],
-        ]}
+        initialValues={[[goldImagePaginationData, { page: 10, perPage: 10, itemCount: 5 }]]}
       >
         <GoldImagesTable goldImages={goldImageData} />
-      </HydrateAtomsTestProvider>,
+      </HydrateAtomsTestProvider>
     );
 
     expect(container.querySelector('thead')).not.toBeInTheDocument();
@@ -159,18 +130,12 @@ describe('Gold images table', () => {
     renderWithRouter(<GoldImagesTable goldImages={goldImageTestData(3)} />);
 
     const links = screen.getAllByRole('link', {
-      name: /view cloud accounts/i,
+      name: /view cloud accounts/i
     });
 
     expect(links).toHaveLength(3);
-    expect(links[0]).toHaveAttribute(
-      'href',
-      expect.stringContaining(Paths.CloudAccounts),
-    );
-    expect(links[0]).toHaveAttribute(
-      'href',
-      expect.stringContaining('shortName'),
-    );
+    expect(links[0]).toHaveAttribute('href', expect.stringContaining(Paths.CloudAccounts));
+    expect(links[0]).toHaveAttribute('href', expect.stringContaining('shortName'));
     expect(links[0]).toHaveAttribute('href', expect.stringContaining('AWS'));
   });
 });

--- a/src/Components/GoldImages/__tests__/GoldImagesToolbar.test.tsx
+++ b/src/Components/GoldImages/__tests__/GoldImagesToolbar.test.tsx
@@ -8,13 +8,11 @@ describe('Gold images toolbar', () => {
     const { container } = renderWithRouter(
       <GoldImagesToolbar
         goldImages={{
-          aws: { provider: CloudProviderName.AWS, goldImages: [] },
+          aws: { provider: CloudProviderName.AWS, goldImages: [] }
         }}
-      />,
+      />
     );
 
-    expect(
-      container.querySelector('[data-ouia-component-type="PF6/Toolbar"]'),
-    ).not.toBeNull();
+    expect(container.querySelector('[data-ouia-component-type="PF6/Toolbar"]')).not.toBeNull();
   });
 });

--- a/src/Components/Hello/index.tsx
+++ b/src/Components/Hello/index.tsx
@@ -5,6 +5,4 @@ interface HelloProps {
   name: string;
 }
 
-export const Hello = ({ name }: HelloProps) => (
-  <Content component="p">Hello, {name}</Content>
-);
+export const Hello = ({ name }: HelloProps) => <Content component="p">Hello, {name}</Content>;

--- a/src/Components/MarketPlacePurchases/MarketplacePurchasesPagination.tsx
+++ b/src/Components/MarketPlacePurchases/MarketplacePurchasesPagination.tsx
@@ -7,12 +7,7 @@ type MarketplacePurchasesPaginationProps = {
 };
 
 export const MarketplacePurchasesPagination = ({
-  isCompact = false,
+  isCompact = false
 }: MarketplacePurchasesPaginationProps) => {
-  return (
-    <PaginationBase
-      atom={MarketplacePurchasesPaginationData}
-      isCompact={isCompact}
-    />
-  );
+  return <PaginationBase atom={MarketplacePurchasesPaginationData} isCompact={isCompact} />;
 };

--- a/src/Components/MarketPlacePurchases/MarketplacePurchasesTable.tsx
+++ b/src/Components/MarketPlacePurchases/MarketplacePurchasesTable.tsx
@@ -5,7 +5,7 @@ import { MarketplacePurchase } from '../../hooks/api/useMarketplacePurchases';
 import { marketplaceToFriendly } from '../../hooks/util/cloudProviderMaps';
 import {
   generateQueryParamsForData,
-  useQueryParamInformedAtom,
+  useQueryParamInformedAtom
 } from '../../hooks/util/useQueryParam';
 import { MarketplacePurchasesPaginationData } from '../../state/marketplacePurchases';
 import { hasPaginationError } from '../../utils/errors';
@@ -18,19 +18,17 @@ type MarketplacePurchasesTableProps = {
 };
 
 export const MarketplacePurchasesTable = ({
-  marketplacePurchases,
+  marketplacePurchases
 }: MarketplacePurchasesTableProps) => {
   const [pagination, setPagination] = useQueryParamInformedAtom(
     MarketplacePurchasesPaginationData,
-    'pagination',
+    'pagination'
   );
 
   const onInvalidPage = hasPaginationError(pagination);
 
   if (onInvalidPage) {
-    return (
-      <PaginationError pagination={pagination} setPagination={setPagination} />
-    );
+    return <PaginationError pagination={pagination} setPagination={setPagination} />;
   }
 
   return (
@@ -44,11 +42,11 @@ export const MarketplacePurchasesTable = ({
                 'Some providers allow purchases to be shared across multiple provider accounts. The account shown here is the one that paid for the purchase.',
               className: 'repositories-info-tip',
               popoverProps: {
-                headerContent: 'Provider account',
+                headerContent: 'Provider account'
               },
               tooltipProps: {
-                isContentLeftAligned: true,
-              },
+                isContentLeftAligned: true
+              }
             }}
           >
             Marketplace account
@@ -60,11 +58,11 @@ export const MarketplacePurchasesTable = ({
                 'The date shown here reflects the time that Red Hat was informed of the purchase. This date may differ from the date shown by the cloud provider.',
               className: 'date-added-tooltip',
               popoverProps: {
-                headerContent: 'Date Added',
+                headerContent: 'Date Added'
               },
               tooltipProps: {
-                isContentLeftAligned: true,
-              },
+                isContentLeftAligned: true
+              }
             }}
           >
             Date added
@@ -81,15 +79,14 @@ export const MarketplacePurchasesTable = ({
                 <Link
                   to={`../${Paths.CloudAccounts}?${generateQueryParamsForData(
                     [purchase.marketplaceAccount],
-                    'providerAccountID',
+                    'providerAccountID'
                   )}`}
                 >
                    {purchase.marketplaceAccount}
                 </Link>
               </Td>
               <Td dataLabel="Marketplace">
-                {marketplaceToFriendly[purchase.marketplace] ??
-                  purchase.marketplace}
+                {marketplaceToFriendly[purchase.marketplace] ?? purchase.marketplace}
               </Td>
               <Td dataLabel="Date added">{formatDate(purchase.startDate)}</Td>
             </Tr>

--- a/src/Components/MarketPlacePurchases/__tests__/MarketplacePurchasesPagination.test.tsx
+++ b/src/Components/MarketPlacePurchases/__tests__/MarketplacePurchasesPagination.test.tsx
@@ -6,7 +6,7 @@ import { MarketplacePurchasesPagination } from '../MarketplacePurchasesPaginatio
 import { MarketplacePurchasesPaginationData } from '../../../state/marketplacePurchases';
 
 const MarketplacePurchasesPaginationWithState = ({
-  init,
+  init
 }: {
   init: {
     page: number;
@@ -14,9 +14,7 @@ const MarketplacePurchasesPaginationWithState = ({
     itemCount: number;
   };
 }) => (
-  <HydrateAtomsTestProvider
-    initialValues={[[MarketplacePurchasesPaginationData, init]]}
-  >
+  <HydrateAtomsTestProvider initialValues={[[MarketplacePurchasesPaginationData, init]]}>
     <MarketplacePurchasesPagination />
   </HydrateAtomsTestProvider>
 );
@@ -25,9 +23,9 @@ describe('Marketplace Purchases Pagination', () => {
   it('renders', () => {
     const { container } = renderWithRouter(<MarketplacePurchasesPagination />);
 
-    expect(
-      container.querySelector('.pf-v6-c-pagination__total-items')?.textContent,
-    ).toContain('0 - 0');
+    expect(container.querySelector('.pf-v6-c-pagination__total-items')?.textContent).toContain(
+      '0 - 0'
+    );
   });
 
   it('goes to the next page', async () => {
@@ -36,33 +34,29 @@ describe('Marketplace Purchases Pagination', () => {
         init={{
           page: 1,
           perPage: 10,
-          itemCount: 150,
+          itemCount: 150
         }}
-      />,
+      />
     );
 
-    const nextButton = container.querySelector(
-      '[aria-label="Go to next page"]',
-    );
+    const nextButton = container.querySelector('[aria-label="Go to next page"]');
 
     if (!nextButton) {
       throw new Error('Next page button not found');
     }
 
     await waitFor(() => {
-      expect(
-        container.querySelector('.pf-v6-c-pagination__total-items')
-          ?.textContent,
-      ).toContain('1 - 10 of 150');
+      expect(container.querySelector('.pf-v6-c-pagination__total-items')?.textContent).toContain(
+        '1 - 10 of 150'
+      );
     });
 
     fireEvent.click(nextButton);
 
     await waitFor(() => {
-      expect(
-        container.querySelector('.pf-v6-c-pagination__total-items')
-          ?.textContent,
-      ).toContain('11 - 20 of 150');
+      expect(container.querySelector('.pf-v6-c-pagination__total-items')?.textContent).toContain(
+        '11 - 20 of 150'
+      );
     });
   });
 
@@ -72,33 +66,29 @@ describe('Marketplace Purchases Pagination', () => {
         init={{
           page: 2,
           perPage: 10,
-          itemCount: 150,
+          itemCount: 150
         }}
-      />,
+      />
     );
 
-    const previousButton = container.querySelector(
-      '[aria-label="Go to previous page"]',
-    );
+    const previousButton = container.querySelector('[aria-label="Go to previous page"]');
 
     if (!previousButton) {
       throw new Error('Previous page button not found');
     }
 
     await waitFor(() => {
-      expect(
-        container.querySelector('.pf-v6-c-pagination__total-items')
-          ?.textContent,
-      ).toContain('11 - 20 of 150');
+      expect(container.querySelector('.pf-v6-c-pagination__total-items')?.textContent).toContain(
+        '11 - 20 of 150'
+      );
     });
 
     fireEvent.click(previousButton);
 
     await waitFor(() => {
-      expect(
-        container.querySelector('.pf-v6-c-pagination__total-items')
-          ?.textContent,
-      ).toContain('1 - 10 of 150');
+      expect(container.querySelector('.pf-v6-c-pagination__total-items')?.textContent).toContain(
+        '1 - 10 of 150'
+      );
     });
   });
 
@@ -108,13 +98,11 @@ describe('Marketplace Purchases Pagination', () => {
         init={{
           page: 1,
           perPage: 10,
-          itemCount: 150,
+          itemCount: 150
         }}
-      />,
+      />
     );
 
-    expect(
-      container.querySelector('[aria-label="Go to previous page"]'),
-    ).toBeDisabled();
+    expect(container.querySelector('[aria-label="Go to previous page"]')).toBeDisabled();
   });
 });

--- a/src/Components/MarketPlacePurchases/__tests__/MarketplacePurchasesTable.test.tsx
+++ b/src/Components/MarketPlacePurchases/__tests__/MarketplacePurchasesTable.test.tsx
@@ -13,27 +13,22 @@ const makeMarketplacePurchases = (count: number): MarketplacePurchase[] =>
     marketplaceAccount: `account-${index}`,
     marketplace: index % 2 === 0 ? 'aws_marketplace' : 'azure_marketplace',
     startDate: `2026-01-${String(index + 1).padStart(2, '0')}`,
-    skus: [`SKU-${index}`],
+    skus: [`SKU-${index}`]
   }));
 
 const defaultPagination = {
   page: 1,
   perPage: 10,
-  itemCount: 10,
+  itemCount: 10
 };
 
-const renderTable = (
-  purchases: MarketplacePurchase[],
-  pagination = defaultPagination,
-) =>
+const renderTable = (purchases: MarketplacePurchase[], pagination = defaultPagination) =>
   renderWithRouter(
-    <HydrateAtomsTestProvider
-      initialValues={[[MarketplacePurchasesPaginationData, pagination]]}
-    >
+    <HydrateAtomsTestProvider initialValues={[[MarketplacePurchasesPaginationData, pagination]]}>
             
       <MarketplacePurchasesTable marketplacePurchases={purchases} />
           
-    </HydrateAtomsTestProvider>,
+    </HydrateAtomsTestProvider>
   );
 
 describe('MarketplacePurchasesTable', () => {
@@ -42,8 +37,8 @@ describe('MarketplacePurchasesTable', () => {
 
     expect(
       screen.getByRole('grid', {
-        name: /marketplace purchases table/i,
-      }),
+        name: /marketplace purchases table/i
+      })
     ).toBeInTheDocument();
   });
 
@@ -76,12 +71,10 @@ describe('MarketplacePurchasesTable', () => {
     renderTable(makeMarketplacePurchases(25), {
       page: 1,
       perPage: 10,
-      itemCount: 25,
+      itemCount: 25
     });
 
-    expect(
-      screen.queryByText(/No results for current page/i),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/No results for current page/i)).not.toBeInTheDocument();
   });
 
   it('renders pagination error when page exceeds item count', () => {
@@ -90,17 +83,15 @@ describe('MarketplacePurchasesTable', () => {
     renderTable(purchases, {
       page: 10,
       perPage: 10,
-      itemCount: 5,
+      itemCount: 5
     });
 
-    expect(
-      screen.getByText(/No results for current page/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/No results for current page/i)).toBeInTheDocument();
 
     expect(
       screen.getByRole('button', {
-        name: /return to page 1/i,
-      }),
+        name: /return to page 1/i
+      })
     ).toBeInTheDocument();
   });
 
@@ -110,7 +101,7 @@ describe('MarketplacePurchasesTable', () => {
     renderTable(purchases, {
       page: 10,
       perPage: 10,
-      itemCount: 5,
+      itemCount: 5
     });
 
     expect(screen.queryByText('Offering name')).not.toBeInTheDocument();
@@ -119,8 +110,8 @@ describe('MarketplacePurchasesTable', () => {
 
     expect(
       screen.queryByRole('grid', {
-        name: /marketplace purchases table/i,
-      }),
+        name: /marketplace purchases table/i
+      })
     ).not.toBeInTheDocument();
   });
 
@@ -130,26 +121,20 @@ describe('MarketplacePurchasesTable', () => {
     renderTable(purchases, {
       page: 10,
       perPage: 10,
-      itemCount: 5,
+      itemCount: 5
     });
 
-    expect(
-      screen.getByText(/No results for current page/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/No results for current page/i)).toBeInTheDocument();
 
     fireEvent.click(
       screen.getByRole('button', {
-        name: /return to page 1/i,
-      }),
+        name: /return to page 1/i
+      })
     );
 
-    expect(
-      screen.queryByText(/No results for current page/i),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/No results for current page/i)).not.toBeInTheDocument();
 
-    await waitFor(() =>
-      expect(screen.getByText(purchases[0].offeringName)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(purchases[0].offeringName)).toBeInTheDocument());
   });
 
   describe('cloud account link', () => {
@@ -158,9 +143,7 @@ describe('MarketplacePurchasesTable', () => {
       renderTable(marketplacePurchases);
 
       expect(
-        screen
-          .getByText(marketplacePurchases[0].marketplaceAccount)
-          .getAttribute('href'),
+        screen.getByText(marketplacePurchases[0].marketplaceAccount).getAttribute('href')
       ).not.toBeNull();
     });
 
@@ -169,11 +152,9 @@ describe('MarketplacePurchasesTable', () => {
       renderTable(marketplacePurchases);
 
       expect(
-        screen
-          .getByText(marketplacePurchases[0].marketplaceAccount)
-          .getAttribute('href'),
+        screen.getByText(marketplacePurchases[0].marketplaceAccount).getAttribute('href')
       ).toBe(
-        `/${Paths.CloudAccounts}?providerAccountID=${encodeURI(`["${marketplacePurchases[0].marketplaceAccount}"]`)}`,
+        `/${Paths.CloudAccounts}?providerAccountID=${encodeURI(`["${marketplacePurchases[0].marketplaceAccount}"]`)}`
       );
     });
   });

--- a/src/Components/MarketPlacePurchases/__tests__/MarktetplacePurchasesToolbar.test.tsx
+++ b/src/Components/MarketPlacePurchases/__tests__/MarktetplacePurchasesToolbar.test.tsx
@@ -14,28 +14,26 @@ const renderToolbar = () =>
           {
             page: 1,
             perPage: 10,
-            itemCount: 25,
-          },
-        ],
+            itemCount: 25
+          }
+        ]
       ]}
     >
       <MarketplacePurchasesToolbar />
-    </HydrateAtomsTestProvider>,
+    </HydrateAtomsTestProvider>
   );
 
 describe('MarketplacePurchasesToolbar', () => {
   it('renders the toolbar', () => {
     const { container } = renderToolbar();
-    expect(
-      container.querySelector('#marketplace-purchases-toolbar'),
-    ).toBeInTheDocument();
+    expect(container.querySelector('#marketplace-purchases-toolbar')).toBeInTheDocument();
   });
   it('renders the compact pagination component', () => {
     renderToolbar();
     expect(
       screen.getByRole('button', {
-        name: /1\s*[–-]\s*10 of 25/i,
-      }),
+        name: /1\s*[–-]\s*10 of 25/i
+      })
     ).toBeInTheDocument();
   });
 });

--- a/src/Components/MarketPlacePurchases/__tests__/NoMarketplacePurchases.test.tsx
+++ b/src/Components/MarketPlacePurchases/__tests__/NoMarketplacePurchases.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { NoMarketplacePurchases } from '../NoMarketplacePurchases';
 
 jest.mock('@patternfly/react-icons', () => ({
-  CubesIcon: () => <div data-testid="mock-cubes-icon" />,
+  CubesIcon: () => <div data-testid="mock-cubes-icon" />
 }));
 
 describe('NoMarketplacePurchases', () => {
@@ -12,17 +12,15 @@ describe('NoMarketplacePurchases', () => {
 
     expect(
       screen.getByRole('heading', {
-        level: 4,
-      }),
+        level: 4
+      })
     ).toHaveTextContent('No Marketplace Purchases Available');
   });
 
   it('renders the empty state body', () => {
     render(<NoMarketplacePurchases />);
 
-    expect(
-      screen.getByText(/you have no marketplace purchases/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/you have no marketplace purchases/i)).toBeInTheDocument();
   });
 
   it('renders the cubes icon', () => {

--- a/src/Components/shared/PaginationBase.tsx
+++ b/src/Components/shared/PaginationBase.tsx
@@ -12,12 +12,11 @@ interface PaginationBaseProps {
   isCompact?: boolean;
 }
 
-export const PaginationBase = ({
-  atom,
-  isCompact = false,
-}: PaginationBaseProps) => {
-  const [{ perPage, page, itemCount }, setPagination] =
-    useQueryParamInformedAtom(atom, 'pagination');
+export const PaginationBase = ({ atom, isCompact = false }: PaginationBaseProps) => {
+  const [{ perPage, page, itemCount }, setPagination] = useQueryParamInformedAtom(
+    atom,
+    'pagination'
+  );
 
   return (
     <Pagination
@@ -29,14 +28,14 @@ export const PaginationBase = ({
         setPagination({
           page: newPage,
           perPage,
-          itemCount,
+          itemCount
         });
       }}
       onPerPageSelect={(_evt, newPerPage, newPage) => {
         setPagination({
           page: newPage,
           perPage: newPerPage,
-          itemCount,
+          itemCount
         });
       }}
     />

--- a/src/Components/shared/PaginationError.tsx
+++ b/src/Components/shared/PaginationError.tsx
@@ -8,18 +8,13 @@ interface PaginationErrorProps {
   setPagination: (v: PaginationData) => void;
 }
 
-export const PaginationError = ({
-  pagination,
-  setPagination,
-}: PaginationErrorProps) => {
+export const PaginationError = ({ pagination, setPagination }: PaginationErrorProps) => {
   return (
     <EmptyState variant="lg" icon={InfoCircleIcon}>
       <EmptyStateBody>
         No results for current page. <br />
         <br />
-        <Button onClick={() => setPagination({ ...pagination, page: 1 })}>
-          Return to page 1
-        </Button>
+        <Button onClick={() => setPagination({ ...pagination, page: 1 })}>Return to page 1</Button>
       </EmptyStateBody>
     </EmptyState>
   );

--- a/src/Components/shared/__tests__/Pagination.test.tsx
+++ b/src/Components/shared/__tests__/Pagination.test.tsx
@@ -3,14 +3,14 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { PaginationBase } from '../PaginationBase';
 import { atom } from 'jotai';
 jest.mock('../../../hooks/util/useQueryParam', () => ({
-  useQueryParamInformedAtom: jest.fn(),
+  useQueryParamInformedAtom: jest.fn()
 }));
 import { useQueryParamInformedAtom } from '../../../hooks/util/useQueryParam';
 const mockSetPagination = jest.fn();
 const testAtom = atom({
   page: 1,
   perPage: 10,
-  itemCount: 100,
+  itemCount: 100
 });
 const setup = (
   override?: Partial<{
@@ -18,19 +18,17 @@ const setup = (
     perPage: number;
     itemCount: number;
     isCompact: boolean;
-  }>,
+  }>
 ) => {
   (useQueryParamInformedAtom as jest.Mock).mockReturnValue([
     {
       page: override?.page ?? 1,
       perPage: override?.perPage ?? 10,
-      itemCount: override?.itemCount ?? 100,
+      itemCount: override?.itemCount ?? 100
     },
-    mockSetPagination,
+    mockSetPagination
   ]);
-  return render(
-    <PaginationBase atom={testAtom} isCompact={override?.isCompact ?? false} />,
-  );
+  return render(<PaginationBase atom={testAtom} isCompact={override?.isCompact ?? false} />);
 };
 describe('PaginationBase', () => {
   beforeEach(() => {
@@ -38,24 +36,20 @@ describe('PaginationBase', () => {
   });
   it('renders pagination with default values', () => {
     setup();
-    expect(
-      screen.getByRole('button', { name: /go to next page/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /go to next page/i })).toBeInTheDocument();
 
-    expect(
-      screen.getByRole('button', { name: /go to previous page/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /go to previous page/i })).toBeInTheDocument();
   });
   it('updates page when page is changed', () => {
     setup();
     const nextPageButton = screen.getByRole('button', {
-      name: /go to next page/i,
+      name: /go to next page/i
     });
     fireEvent.click(nextPageButton);
     expect(mockSetPagination).toHaveBeenCalledWith({
       perPage: 10,
       itemCount: 100,
-      page: 2,
+      page: 2
     });
   });
   it('respects isCompact prop', () => {

--- a/src/Components/shared/__tests__/PaginationError.test.tsx
+++ b/src/Components/shared/__tests__/PaginationError.test.tsx
@@ -7,41 +7,24 @@ describe('PaginationError', () => {
   const defaultPagination: PaginationData = {
     page: 5,
     perPage: 10,
-    itemCount: 25,
+    itemCount: 25
   };
 
   it('renders the error message', () => {
-    render(
-      <PaginationError
-        pagination={defaultPagination}
-        setPagination={() => {}}
-      />,
-    );
+    render(<PaginationError pagination={defaultPagination} setPagination={() => {}} />);
 
-    expect(
-      screen.getByText(/No results for current page/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/No results for current page/i)).toBeInTheDocument();
   });
 
   it('renders the return to page 1 button', () => {
-    render(
-      <PaginationError
-        pagination={defaultPagination}
-        setPagination={() => {}}
-      />,
-    );
+    render(<PaginationError pagination={defaultPagination} setPagination={() => {}} />);
 
-    expect(
-      screen.getByRole('button', { name: /return to page 1/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /return to page 1/i })).toBeInTheDocument();
   });
 
   it('renders as an empty state with large variant', () => {
     const { container } = render(
-      <PaginationError
-        pagination={defaultPagination}
-        setPagination={() => {}}
-      />,
+      <PaginationError pagination={defaultPagination} setPagination={() => {}} />
     );
 
     const emptyState = container.querySelector('.pf-v6-c-empty-state');

--- a/src/Components/util/__tests__/Loading.test.tsx
+++ b/src/Components/util/__tests__/Loading.test.tsx
@@ -6,8 +6,6 @@ describe('Loading', () => {
   it('renders', () => {
     const { container } = render(<Loading />);
 
-    expect(
-      container.querySelector('[aria-valuetext="Loading..."]'),
-    ).toBeInTheDocument();
+    expect(container.querySelector('[aria-valuetext="Loading..."]')).toBeInTheDocument();
   });
 });

--- a/src/Components/util/testing/HydrateAtomsTestProvider.tsx
+++ b/src/Components/util/testing/HydrateAtomsTestProvider.tsx
@@ -13,17 +13,14 @@ interface HydrateAtomsInitialValues {
   children: ReactNode;
 }
 
-const AtomsHydrator = ({
-  initialValues,
-  children,
-}: HydrateAtomsInitialValues) => {
+const AtomsHydrator = ({ initialValues, children }: HydrateAtomsInitialValues) => {
   useHydrateAtoms(new Map(initialValues));
   return children;
 };
 
 export const HydrateAtomsTestProvider = ({
   initialValues,
-  children,
+  children
 }: HydrateAtomsInitialValues) => {
   return (
     <Provider>

--- a/src/Components/util/testing/ManipulatableQueryWrapper.tsx
+++ b/src/Components/util/testing/ManipulatableQueryWrapper.tsx
@@ -5,14 +5,14 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: false,
-      staleTime: Infinity,
-    },
-  },
+      staleTime: Infinity
+    }
+  }
 });
 
 export const ManipulatableQueryWrapper = (children: JSX.Element) => ({
   ComponentWithQueryClient: () => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   ),
-  queryClient,
+  queryClient
 });

--- a/src/Components/util/testing/mockApiResponse.tsx
+++ b/src/Components/util/testing/mockApiResponse.tsx
@@ -16,20 +16,16 @@ export const enableMocks = () => {
           json: () => {
             return Promise.resolve(mockMap[url].body);
           },
-          ok: mockMap[url].ok,
+          ok: mockMap[url].ok
         });
       } else {
         return Promise.reject('No url mocked');
       }
-    }) as jest.Mock,
+    }) as jest.Mock
   );
 };
 
-export const mockApiResponse = (
-  url: string,
-  payload: unknown,
-  success: boolean,
-) => {
+export const mockApiResponse = (url: string, payload: unknown, success: boolean) => {
   mockMap[url] = { body: payload, ok: success };
 };
 
@@ -49,22 +45,20 @@ export class RequestMocks {
             json: () => {
               return Promise.resolve(this.map[url].body);
             },
-            ok: this.map[url].ok,
+            ok: this.map[url].ok
           });
         } else {
           return Promise.reject('No url mocked');
         }
-      }) as jest.Mock,
+      }) as jest.Mock
     );
 
     this.queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
+      defaultOptions: { queries: { retry: false } }
     });
 
     this.wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={this.queryClient}>
-        {children}
-      </QueryClientProvider>
+      <QueryClientProvider client={this.queryClient}>{children}</QueryClientProvider>
     );
   }
 

--- a/src/Components/util/useClearCloudAccountFilters.tsx
+++ b/src/Components/util/useClearCloudAccountFilters.tsx
@@ -3,26 +3,17 @@ import {
   CloudAccountsPaginationData,
   cloudAccountIDFilterData,
   cloudProviderFilterData,
-  goldImageStatusFilterData,
+  goldImageStatusFilterData
 } from '../../state/cloudAccounts';
 
 export const useClearCloudAccountFilters = () => {
   const [pagination, setPagination] = useQueryParamInformedAtom(
     CloudAccountsPaginationData,
-    'pagination',
+    'pagination'
   );
-  const [, setProviders] = useQueryParamInformedAtom(
-    cloudProviderFilterData,
-    'shortName',
-  );
-  const [, setStatuses] = useQueryParamInformedAtom(
-    goldImageStatusFilterData,
-    'goldImageAccess',
-  );
-  const [, setAccountID] = useQueryParamInformedAtom(
-    cloudAccountIDFilterData,
-    'providerAccountID',
-  );
+  const [, setProviders] = useQueryParamInformedAtom(cloudProviderFilterData, 'shortName');
+  const [, setStatuses] = useQueryParamInformedAtom(goldImageStatusFilterData, 'goldImageAccess');
+  const [, setAccountID] = useQueryParamInformedAtom(cloudAccountIDFilterData, 'providerAccountID');
 
   return () => {
     setProviders([]);

--- a/src/Pages/CloudAccountsPage/CloudAccountsPage.tsx
+++ b/src/Pages/CloudAccountsPage/CloudAccountsPage.tsx
@@ -13,13 +13,13 @@ import { Paths } from '../../utils/routing';
 import { NoCloudAccounts } from '../../Components/CloudAccounts/NoCloudAccounts';
 import {
   useQueryParamInformedAtom,
-  useQueryParamInformedState,
+  useQueryParamInformedState
 } from '../../hooks/util/useQueryParam';
 import {
   CloudAccountsPaginationData,
   cloudAccountIDFilterData,
   cloudProviderFilterData,
-  goldImageStatusFilterData,
+  goldImageStatusFilterData
 } from '../../state/cloudAccounts';
 import { SortByDirection } from '@patternfly/react-table';
 import { hasPaginationError } from '../../utils/errors';
@@ -30,38 +30,36 @@ import { Relation, useHasRelation } from '../../hooks/util/useHasRelation';
 export const CloudAccountsPage = () => {
   const [pagination, setPagination] = useQueryParamInformedAtom(
     CloudAccountsPaginationData,
-    'pagination',
+    'pagination'
   );
 
   const [sortBy, setSortBy] = useQueryParamInformedState<string | undefined>(
     undefined,
-    'cloudAccountsActiveSortBy',
+    'cloudAccountsActiveSortBy'
   );
-  const [sortDir, setSortDir] = useQueryParamInformedState<
-    SortByDirection | undefined
-  >(undefined, 'cloudAccountsActiveSortDir');
+  const [sortDir, setSortDir] = useQueryParamInformedState<SortByDirection | undefined>(
+    undefined,
+    'cloudAccountsActiveSortDir'
+  );
 
   const { page, perPage } = pagination;
 
-  const [selectedProviders] = useQueryParamInformedAtom(
-    cloudProviderFilterData,
-    'shortName',
-  );
+  const [selectedProviders] = useQueryParamInformedAtom(cloudProviderFilterData, 'shortName');
 
   const [selectedStatuses] = useQueryParamInformedAtom(
     goldImageStatusFilterData,
-    'goldImageAccess',
+    'goldImageAccess'
   );
 
   const [accountIDSearch] = useQueryParamInformedAtom(
     cloudAccountIDFilterData,
-    'providerAccountID',
+    'providerAccountID'
   );
 
   const {
     data: cloudAccountsResponse,
     isError: isCloudAccountsError,
-    isLoading: areCloudAccountsLoading,
+    isLoading: areCloudAccountsLoading
   } = useCloudAccounts({
     limit: perPage,
     offset: (page - 1) * perPage,
@@ -69,7 +67,7 @@ export const CloudAccountsPage = () => {
     sortDirection: sortDir,
     shortName: selectedProviders,
     goldImageAccess: selectedStatuses,
-    providerAccountID: accountIDSearch,
+    providerAccountID: accountIDSearch
   });
 
   const accounts = cloudAccountsResponse?.body ?? [];
@@ -77,7 +75,7 @@ export const CloudAccountsPage = () => {
   const availableProviders: CloudProviderShortname[] = [
     CloudProviderShortname.AWS,
     CloudProviderShortname.GCP,
-    CloudProviderShortname.AZURE,
+    CloudProviderShortname.AZURE
   ];
 
   const availableStatuses = ['Granted', 'Requested', 'Failed'];
@@ -88,23 +86,18 @@ export const CloudAccountsPage = () => {
     if (cloudAccountsResponse?.pagination) {
       setPagination({
         ...pagination,
-        itemCount: cloudAccountsResponse.pagination.total,
+        itemCount: cloudAccountsResponse.pagination.total
       });
     }
   }, [cloudAccountsResponse?.pagination?.total]);
 
-  const { has: canReadCloudAccess, isLoading } = useHasRelation(
-    Relation.CLOUD_ACCESS_VIEW,
-  );
+  const { has: canReadCloudAccess, isLoading } = useHasRelation(Relation.CLOUD_ACCESS_VIEW);
 
   const hasActiveFilters =
-    selectedProviders.length > 0 ||
-    selectedStatuses.length > 0 ||
-    accountIDSearch !== '';
+    selectedProviders.length > 0 || selectedStatuses.length > 0 || accountIDSearch !== '';
 
   const shouldShowNoResults = !hasAccounts && hasActiveFilters;
-  const shouldShowEmptyState =
-    !hasAccounts && !hasActiveFilters && !hasPaginationError(pagination);
+  const shouldShowEmptyState = !hasAccounts && !hasActiveFilters && !hasPaginationError(pagination);
 
   if (isLoading) return <Loading />;
   if (!canReadCloudAccess) return <Navigate to={`../${Paths.NoPermissions}`} />;

--- a/src/Pages/CloudAccountsPage/__tests__/CloudAccountsPage.test.tsx
+++ b/src/Pages/CloudAccountsPage/__tests__/CloudAccountsPage.test.tsx
@@ -10,11 +10,11 @@ const mockNavigate = jest.fn();
 
 jest.mock('@project-kessel/react-kessel-access-check', () => ({
   fetchDefaultWorkspace: jest.fn(() => Promise.resolve({ id: 'org-id' })),
-  useAccessCheckContext: jest.fn(() => ({})),
+  useAccessCheckContext: jest.fn(() => ({}))
 }));
 
 jest.mock('@project-kessel/react-kessel-access-check/core/api-client', () => ({
-  checkSelf: (...args: unknown[]) => mockCheck(...args),
+  checkSelf: (...args: unknown[]) => mockCheck(...args)
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -23,7 +23,7 @@ jest.mock('react-router-dom', () => ({
   Navigate: ({ to }: { to: string }) => {
     mockNavigate(to);
     return <div data-testid="navigate" />;
-  },
+  }
 }));
 
 const defaultQueryParams = {
@@ -33,18 +33,16 @@ const defaultQueryParams = {
   sortDirection: undefined,
   shortName: [],
   goldImageAccess: [],
-  providerAccountID: '',
+  providerAccountID: ''
 };
 
-const { ComponentWithQueryClient, queryClient } = ManipulatableQueryWrapper(
-  <CloudAccountsPage />,
-);
+const { ComponentWithQueryClient, queryClient } = ManipulatableQueryWrapper(<CloudAccountsPage />);
 
 beforeEach(() => {
   queryClient.clear();
 
   mockCheck.mockResolvedValue({
-    allowed: 'ALLOWED_TRUE',
+    allowed: 'ALLOWED_TRUE'
   });
 });
 
@@ -60,15 +58,15 @@ it('renders cloud accounts page', async () => {
         providerAccountID: 'abc',
         shortName: 'AWS',
         goldImageAccess: 'Granted',
-        dateAdded: '2025-01-01',
-      },
+        dateAdded: '2025-01-01'
+      }
     ],
     pagination: {
       total: 1,
       count: 1,
       limit: 10,
-      offset: 0,
-    },
+      offset: 0
+    }
   });
 
   renderWithRouter(<ComponentWithQueryClient />);
@@ -79,13 +77,13 @@ it('renders cloud accounts page', async () => {
 it('shows empty state when no accounts exist', async () => {
   queryClient.setQueryData(['cloudAccounts', defaultQueryParams], {
     body: [],
-    pagination: { total: 0, count: 0, limit: 10, offset: 0 },
+    pagination: { total: 0, count: 0, limit: 10, offset: 0 }
   });
 
   renderWithRouter(<ComponentWithQueryClient />);
 
   const integrationsLink = await screen.findByRole('link', {
-    name: /integrations/i,
+    name: /integrations/i
   });
 
   expect(integrationsLink).toHaveAttribute('href', '/settings/integrations/');
@@ -93,7 +91,7 @@ it('shows empty state when no accounts exist', async () => {
 
 it('shows loading state while cloud accounts are loading', async () => {
   queryClient.setQueryDefaults(['cloudAccounts'], {
-    queryFn: () => new Promise(() => {}),
+    queryFn: () => new Promise(() => {})
   });
 
   renderWithRouter(<ComponentWithQueryClient />);
@@ -103,7 +101,7 @@ it('shows loading state while cloud accounts are loading', async () => {
 
 it('redirects when user lacks permission', async () => {
   mockCheck.mockResolvedValueOnce({
-    allowed: 'ALLOWED_FALSE',
+    allowed: 'ALLOWED_FALSE'
   });
 
   renderWithRouter(<ComponentWithQueryClient />);

--- a/src/Pages/GoldImagesPage/GoldImagesPage.tsx
+++ b/src/Pages/GoldImagesPage/GoldImagesPage.tsx
@@ -17,11 +17,9 @@ export const GoldImagesPage = () => {
   const {
     data: goldImages,
     isError: isGoldImageError,
-    isLoading: areGoldImagesLoading,
+    isLoading: areGoldImagesLoading
   } = useGoldImages();
-  const { has: canReadCloudAccess, isLoading } = useHasRelation(
-    Relation.CLOUD_ACCESS_VIEW,
-  );
+  const { has: canReadCloudAccess, isLoading } = useHasRelation(Relation.CLOUD_ACCESS_VIEW);
 
   // Permission gate
   if (isLoading) return <Loading />;
@@ -38,10 +36,10 @@ export const GoldImagesPage = () => {
       <PageHeader>
         <Content component="h1">Gold Images</Content>
         <Content component="p">
-          This is a listing of the gold images available to your organization,
-          based on your subscriptions. Learn more about gold images. To see
-          which cloud accounts have gold image access enabled, view the list of
-          your <Link to={`../${Paths.CloudAccounts}`}>cloud accounts.</Link>
+          This is a listing of the gold images available to your organization, based on your
+          subscriptions. Learn more about gold images. To see which cloud accounts have gold image
+          access enabled, view the list of your{' '}
+          <Link to={`../${Paths.CloudAccounts}`}>cloud accounts.</Link>
         </Content>
       </PageHeader>
       <Section>

--- a/src/Pages/GoldImagesPage/__tests__/GoldImagesPage.test.tsx
+++ b/src/Pages/GoldImagesPage/__tests__/GoldImagesPage.test.tsx
@@ -14,34 +14,32 @@ jest.mock('react-router-dom', () => ({
   Navigate: ({ to }: { to: string }) => {
     mockNavigate(to);
     return <div data-testid="navigate" />;
-  },
+  }
 }));
 
 jest.mock('@project-kessel/react-kessel-access-check', () => ({
   fetchDefaultWorkspace: jest.fn(() => Promise.resolve({ id: 'org-id' })),
-  useAccessCheckContext: jest.fn(() => ({})),
+  useAccessCheckContext: jest.fn(() => ({}))
 }));
 
 jest.mock('@project-kessel/react-kessel-access-check/core/api-client', () => ({
-  checkSelf: (...args: unknown[]) => mockCheck(...args),
+  checkSelf: (...args: unknown[]) => mockCheck(...args)
 }));
 
-const { ComponentWithQueryClient, queryClient } = ManipulatableQueryWrapper(
-  <GoldImagesPage />,
-);
+const { ComponentWithQueryClient, queryClient } = ManipulatableQueryWrapper(<GoldImagesPage />);
 
 describe('Gold images page', () => {
   beforeEach(() => {
     queryClient.clear();
 
     queryClient.setQueryData(['goldImages'], {
-      AWS: { provider: 'AWS', goldImages: [] },
+      AWS: { provider: 'AWS', goldImages: [] }
     });
     mockCheck.mockClear();
     mockNavigate.mockClear();
 
     mockCheck.mockResolvedValue({
-      allowed: 'ALLOWED_TRUE',
+      allowed: 'ALLOWED_TRUE'
     });
   });
 
@@ -53,14 +51,12 @@ describe('Gold images page', () => {
   it('renders', async () => {
     renderWithRouter(<ComponentWithQueryClient />);
 
-    await waitFor(() =>
-      expect(screen.queryByText('Gold Images')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.queryByText('Gold Images')).toBeInTheDocument());
   });
 
   it('redirects on missing permission', async () => {
     mockCheck.mockResolvedValueOnce({
-      allowed: 'ALLOWED_FALSE',
+      allowed: 'ALLOWED_FALSE'
     });
 
     renderWithRouter(<ComponentWithQueryClient />);
@@ -75,8 +71,6 @@ describe('Gold images page', () => {
 
     renderWithRouter(<ComponentWithQueryClient />);
 
-    await waitFor(() =>
-      expect(screen.queryByText('No gold images')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.queryByText('No gold images')).toBeInTheDocument());
   });
 });

--- a/src/Pages/MarketplacePurchasesPage/MarketplacePurchasesPage.tsx
+++ b/src/Pages/MarketplacePurchasesPage/MarketplacePurchasesPage.tsx
@@ -20,25 +20,25 @@ import { MarketplacePurchasesToolbar } from '../../Components/MarketPlacePurchas
 const MarketplacePurchasesPage = () => {
   const [pagination, setPagination] = useQueryParamInformedAtom(
     MarketplacePurchasesPaginationData,
-    'pagination',
+    'pagination'
   );
 
   const { page, perPage } = pagination;
-  const { has: canReadCloudAccess, isLoading: isPermissionsLoading } =
-    useHasRelation(Relation.CLOUD_ACCESS_VIEW);
-  const canFetchMarketplacePurchases =
-    !isPermissionsLoading && canReadCloudAccess;
+  const { has: canReadCloudAccess, isLoading: isPermissionsLoading } = useHasRelation(
+    Relation.CLOUD_ACCESS_VIEW
+  );
+  const canFetchMarketplacePurchases = !isPermissionsLoading && canReadCloudAccess;
 
   const {
     data: marketplacePurchasesResponse,
     isError: isMarketplacePurchasesError,
-    isLoading: isMarketplacePurchasesLoading,
+    isLoading: isMarketplacePurchasesLoading
   } = useMarketplacePurchases(
     {
       limit: perPage,
-      offset: (page - 1) * perPage,
+      offset: (page - 1) * perPage
     },
-    canFetchMarketplacePurchases,
+    canFetchMarketplacePurchases
   );
   const marketplacePurchases = marketplacePurchasesResponse?.body ?? [];
   const hasMarketplacePurchases = marketplacePurchases.length > 0;
@@ -47,13 +47,12 @@ const MarketplacePurchasesPage = () => {
     if (marketplacePurchasesResponse?.pagination) {
       setPagination({
         ...pagination,
-        itemCount: marketplacePurchasesResponse.pagination.total,
+        itemCount: marketplacePurchasesResponse.pagination.total
       });
     }
   }, [marketplacePurchasesResponse?.pagination?.total]);
 
-  const shouldShowEmptyState =
-    !hasMarketplacePurchases && !hasPaginationError(pagination);
+  const shouldShowEmptyState = !hasMarketplacePurchases && !hasPaginationError(pagination);
 
   if (isPermissionsLoading) {
     return <Loading />;
@@ -97,9 +96,7 @@ const MarketplacePurchasesPage = () => {
           ) : (
             <>
               <MarketplacePurchasesToolbar />
-              <MarketplacePurchasesTable
-                marketplacePurchases={marketplacePurchases}
-              />
+              <MarketplacePurchasesTable marketplacePurchases={marketplacePurchases} />
               <br />
               <MarketplacePurchasesPagination />
             </>

--- a/src/Pages/MarketplacePurchasesPage/__tests__/MarketplacePurchasesPage.test.tsx
+++ b/src/Pages/MarketplacePurchasesPage/__tests__/MarketplacePurchasesPage.test.tsx
@@ -8,48 +8,42 @@ import { useHasRelation } from '../../../hooks/util/useHasRelation';
 import { MarketplacePurchasesPaginationData } from '../../../state/marketplacePurchases';
 jest.mock('../../../hooks/util/useHasRelation', () => ({
   Relation: {
-    CLOUD_ACCESS_VIEW: 'cloud_access_view',
+    CLOUD_ACCESS_VIEW: 'cloud_access_view'
   },
-  useHasRelation: jest.fn(),
+  useHasRelation: jest.fn()
 }));
 
-const mockedUseHasRelation = useHasRelation as jest.MockedFunction<
-  typeof useHasRelation
->;
+const mockedUseHasRelation = useHasRelation as jest.MockedFunction<typeof useHasRelation>;
 const defaultPagination = {
   page: 1,
   perPage: 10,
-  itemCount: 0,
+  itemCount: 0
 };
 
-const marketplacePurchasesQueryKey = [
-  'marketplacePurchases',
-  { limit: 10, offset: 0 },
-];
+const marketplacePurchasesQueryKey = ['marketplacePurchases', { limit: 10, offset: 0 }];
 const mockMarketplacePurchasesResponse = {
   pagination: {
     offset: 0,
     limit: 10,
     count: 2,
-    total: 2,
+    total: 2
   },
   body: [
     {
-      offeringName:
-        'Red Hat OpenShift Streams for Apache Kafka - Testing Purposes Only',
+      offeringName: 'Red Hat OpenShift Streams for Apache Kafka - Testing Purposes Only',
       marketplaceAccount: '665427542893',
       marketplace: 'aws_marketplace',
       startDate: '2025-05-22T18:39:23.826220243Z',
-      skus: ['MW01882'],
+      skus: ['MW01882']
     },
     {
       offeringName: 'Red Hat Enterprise Linux',
       marketplaceAccount: '252b3da5-a55b-4baf-aad0-186a8f3e6fcb',
       marketplace: 'azure_marketplace',
       startDate: '2026-07-13T00:00:00Z',
-      skus: ['RH02612'],
-    },
-  ],
+      skus: ['RH02612']
+    }
+  ]
 };
 
 const TestPage = () => (
@@ -60,16 +54,14 @@ const TestPage = () => (
   </HydrateAtomsTestProvider>
 );
 
-const { ComponentWithQueryClient, queryClient } = ManipulatableQueryWrapper(
-  <TestPage />,
-);
+const { ComponentWithQueryClient, queryClient } = ManipulatableQueryWrapper(<TestPage />);
 
 describe('Marketplace purchases page', () => {
   beforeEach(() => {
     queryClient.clear();
     mockedUseHasRelation.mockReturnValue({
       has: true,
-      isLoading: false,
+      isLoading: false
     });
   });
   afterEach(() => {
@@ -77,65 +69,47 @@ describe('Marketplace purchases page', () => {
     jest.clearAllMocks();
   });
   it('renders the Marketplace Purchases page', async () => {
-    queryClient.setQueryData(
-      marketplacePurchasesQueryKey,
-      mockMarketplacePurchasesResponse,
-    );
+    queryClient.setQueryData(marketplacePurchasesQueryKey, mockMarketplacePurchasesResponse);
     renderWithRouter(<ComponentWithQueryClient />);
     expect(
       await screen.findByRole('heading', {
-        name: /marketplace purchases/i,
-      }),
+        name: /marketplace purchases/i
+      })
     ).toBeInTheDocument();
     expect(
       screen.getByRole('grid', {
-        name: /marketplace purchases table/i,
-      }),
+        name: /marketplace purchases table/i
+      })
     ).toBeInTheDocument();
   });
 
   it('renders marketplace purchase data', async () => {
-    queryClient.setQueryData(
-      marketplacePurchasesQueryKey,
-      mockMarketplacePurchasesResponse,
-    );
+    queryClient.setQueryData(marketplacePurchasesQueryKey, mockMarketplacePurchasesResponse);
     renderWithRouter(<ComponentWithQueryClient />);
     expect(
-      await screen.findByText(
-        'Red Hat OpenShift Streams for Apache Kafka - Testing Purposes Only',
-      ),
+      await screen.findByText('Red Hat OpenShift Streams for Apache Kafka - Testing Purposes Only')
     ).toBeInTheDocument();
     expect(screen.getByText('Red Hat Enterprise Linux')).toBeInTheDocument();
     expect(screen.getByText('665427542893')).toBeInTheDocument();
-    expect(
-      screen.getByText('252b3da5-a55b-4baf-aad0-186a8f3e6fcb'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('252b3da5-a55b-4baf-aad0-186a8f3e6fcb')).toBeInTheDocument();
     expect(screen.getByText('AWS')).toBeInTheDocument();
     expect(screen.getByText('Microsoft Azure')).toBeInTheDocument();
   });
 
   it('renders one row for each marketplace purchase', async () => {
-    queryClient.setQueryData(
-      marketplacePurchasesQueryKey,
-      mockMarketplacePurchasesResponse,
-    );
+    queryClient.setQueryData(marketplacePurchasesQueryKey, mockMarketplacePurchasesResponse);
     renderWithRouter(<ComponentWithQueryClient />);
     await screen.findByText('Red Hat Enterprise Linux');
     expect(screen.getAllByRole('row')).toHaveLength(3);
   });
 
   it('renders pagination using the API total', async () => {
-    queryClient.setQueryData(
-      marketplacePurchasesQueryKey,
-      mockMarketplacePurchasesResponse,
-    );
+    queryClient.setQueryData(marketplacePurchasesQueryKey, mockMarketplacePurchasesResponse);
     const { container } = renderWithRouter(<ComponentWithQueryClient />);
-    expect(
-      await screen.findByText('Red Hat Enterprise Linux'),
-    ).toBeInTheDocument();
-    expect(
-      container.querySelector('.pf-v6-c-pagination__total-items')?.textContent,
-    ).toContain('1 - 2 of 2');
+    expect(await screen.findByText('Red Hat Enterprise Linux')).toBeInTheDocument();
+    expect(container.querySelector('.pf-v6-c-pagination__total-items')?.textContent).toContain(
+      '1 - 2 of 2'
+    );
   });
 
   it('shows the empty state when no marketplace purchases exist', async () => {
@@ -144,68 +118,59 @@ describe('Marketplace purchases page', () => {
         offset: 0,
         limit: 10,
         count: 0,
-        total: 0,
+        total: 0
       },
-      body: [],
+      body: []
     });
 
     renderWithRouter(<ComponentWithQueryClient />);
     expect(
       await screen.findByRole('heading', {
-        name: /no marketplace purchases/i,
-      }),
+        name: /no marketplace purchases/i
+      })
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(/you have no marketplace purchases/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/you have no marketplace purchases/i)).toBeInTheDocument();
     expect(
       screen.queryByRole('grid', {
-        name: /marketplace purchases table/i,
-      }),
+        name: /marketplace purchases table/i
+      })
     ).not.toBeInTheDocument();
   });
 
   it('opens the Marketplace Purchases information popover', async () => {
-    queryClient.setQueryData(
-      marketplacePurchasesQueryKey,
-      mockMarketplacePurchasesResponse,
-    );
+    queryClient.setQueryData(marketplacePurchasesQueryKey, mockMarketplacePurchasesResponse);
     renderWithRouter(<ComponentWithQueryClient />);
     fireEvent.click(
       screen.getByRole('button', {
-        name: /more information about marketplace purchases/i,
-      }),
+        name: /more information about marketplace purchases/i
+      })
     );
     expect(
       await screen.findByText(
-        /marketplace purchases shows purchases made through AWS, Microsoft Azure, Google Cloud, Red Hat Marketplace, and IBM Cloud/i,
-      ),
+        /marketplace purchases shows purchases made through AWS, Microsoft Azure, Google Cloud, Red Hat Marketplace, and IBM Cloud/i
+      )
     ).toBeInTheDocument();
   });
 
   it('shows a loading state while permissions are loading', async () => {
     mockedUseHasRelation.mockReturnValue({
       has: false,
-      isLoading: true,
+      isLoading: true
     });
     queryClient.setQueryDefaults(marketplacePurchasesQueryKey, {
-      queryFn: () => new Promise(() => undefined),
+      queryFn: () => new Promise(() => undefined)
     });
     renderWithRouter(<ComponentWithQueryClient />);
     expect(await screen.findByLabelText(/contents/i)).toBeInTheDocument();
-    expect(
-      screen.queryByText(/you have no marketplace purchases/i),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/you have no marketplace purchases/i)).not.toBeInTheDocument();
   });
 
   it('shows a loading state while marketplace purchases are loading', async () => {
     queryClient.setQueryDefaults(marketplacePurchasesQueryKey, {
-      queryFn: () => new Promise(() => undefined),
+      queryFn: () => new Promise(() => undefined)
     });
     renderWithRouter(<ComponentWithQueryClient />);
     expect(await screen.findByLabelText(/contents/i)).toBeInTheDocument();
-    expect(
-      screen.queryByText(/you have no marketplace purchases/i),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/you have no marketplace purchases/i)).not.toBeInTheDocument();
   });
 });

--- a/src/Pages/NoPermissionsPage/__tests__/NoPermissionsPage.test.tsx
+++ b/src/Pages/NoPermissionsPage/__tests__/NoPermissionsPage.test.tsx
@@ -4,7 +4,5 @@ import { render, screen } from '@testing-library/react';
 
 it('Renders no permissions page', () => {
   render(<NoPermissionsPage />);
-  expect(
-    screen.getByText('You do not have access to Cloud Inventory'),
-  ).toBeInTheDocument();
+  expect(screen.getByText('You do not have access to Cloud Inventory')).toBeInTheDocument();
 });

--- a/src/Pages/OopsPage/__tests__/OopsPage.test.tsx
+++ b/src/Pages/OopsPage/__tests__/OopsPage.test.tsx
@@ -4,7 +4,5 @@ import { render, screen } from '@testing-library/react';
 
 it('Renders no permissions page', () => {
   render(<OopsPage />);
-  expect(
-    screen.getByText('This page is temporarily unavailable'),
-  ).toBeInTheDocument();
+  expect(screen.getByText('This page is temporarily unavailable')).toBeInTheDocument();
 });

--- a/src/Routing.tsx
+++ b/src/Routing.tsx
@@ -1,9 +1,5 @@
 import React, { Suspense, lazy, useMemo } from 'react';
-import {
-  Navigate,
-  Route as RouterRoute,
-  Routes as RouterRoutes,
-} from 'react-router-dom';
+import { Navigate, Route as RouterRoute, Routes as RouterRoutes } from 'react-router-dom';
 import { InvalidObject } from '@redhat-cloud-services/frontend-components/InvalidObject';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import { GoldImagesPage } from './Pages/GoldImagesPage/GoldImagesPage';
@@ -14,56 +10,52 @@ const MarketPlacePurchasesPage = lazy(
   () =>
     import(
       /* webpackChunkName: "MarketPlacePurchasesPage" */ './Pages/MarketplacePurchasesPage/MarketplacePurchasesPage'
-    ),
+    )
 );
-const OopsPage = lazy(
-  () => import(/* webpackChunkName: "OopsPage" */ './Pages/OopsPage/OopsPage'),
-);
+const OopsPage = lazy(() => import(/* webpackChunkName: "OopsPage" */ './Pages/OopsPage/OopsPage'));
 const NoPermissionsPage = lazy(
   () =>
     import(
       /* webpackChunkName: "NoPermissionsPage" */ './Pages/NoPermissionsPage/NoPermissionsPage'
-    ),
+    )
 );
 
 interface RouteDefinition {
   path: Paths;
-  element:
-    | React.LazyExoticComponent<() => React.JSX.Element>
-    | (() => React.JSX.Element);
+  element: React.LazyExoticComponent<() => React.JSX.Element> | (() => React.JSX.Element);
 }
 
 const routes: RouteDefinition[] = [
   {
     path: Paths.NoPermissions,
-    element: NoPermissionsPage,
+    element: NoPermissionsPage
   },
   {
     path: Paths.Oops,
-    element: OopsPage,
+    element: OopsPage
   },
   {
     path: Paths.Root,
-    element: () => <Navigate to={`./${Paths.GoldImages}`} />,
+    element: () => <Navigate to={`./${Paths.GoldImages}`} />
   },
   {
     path: Paths.GoldImages,
-    element: GoldImagesPage,
+    element: GoldImagesPage
   },
   {
     path: Paths.CloudAccounts,
-    element: CloudAccountsPage,
+    element: CloudAccountsPage
   },
   /* Catch all unmatched routes */
   {
     path: Paths.MarketplacePurchases,
-    element: MarketPlacePurchasesPage,
+    element: MarketPlacePurchasesPage
   },
   /* Catch all unmatched routes */
   {
     path: Paths.Catch,
-    element: () => <InvalidObject />,
-  },
+    element: () => <InvalidObject />
+  }
 ];
 
 const renderRoutes = (routes: RouteDefinition[] = []) =>

--- a/src/hooks/api/__tests__/useCloudAccounts.test.ts
+++ b/src/hooks/api/__tests__/useCloudAccounts.test.ts
@@ -18,22 +18,21 @@ describe('useCloudAccounts', () => {
             goldImageAccess: 'Granted',
             dateAdded: '2024-01-01',
             providerLabel: 'Amazon Web Services',
-            shortName: CloudProviderShortname.AWS,
-          },
+            shortName: CloudProviderShortname.AWS
+          }
         ],
         pagination: {
           count: 1,
           limit: 10,
           offset: 0,
-          total: 1,
-        },
+          total: 1
+        }
       },
-      true,
+      true
     );
-    const { result } = renderHook(
-      () => useCloudAccounts({ limit: 10, offset: 0 }),
-      { wrapper: mocks.wrapper },
-    );
+    const { result } = renderHook(() => useCloudAccounts({ limit: 10, offset: 0 }), {
+      wrapper: mocks.wrapper
+    });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.body).toHaveLength(1);
     expect(result.current.data?.pagination.total).toBe(1);
@@ -47,15 +46,14 @@ describe('useCloudAccounts', () => {
           count: 0,
           limit: 10,
           offset: 0,
-          total: 0,
-        },
+          total: 0
+        }
       },
-      true,
+      true
     );
-    const { result } = renderHook(
-      () => useCloudAccounts({ limit: 10, offset: 0 }),
-      { wrapper: mocks.wrapper },
-    );
+    const { result } = renderHook(() => useCloudAccounts({ limit: 10, offset: 0 }), {
+      wrapper: mocks.wrapper
+    });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.body).toEqual([]);
   });
@@ -68,50 +66,36 @@ describe('useCloudAccounts', () => {
           count: 5,
           limit: 5,
           offset: 10,
-          total: 42,
-        },
+          total: 42
+        }
       },
-      true,
+      true
     );
-    const { result } = renderHook(
-      () => useCloudAccounts({ limit: 5, offset: 10 }),
-      { wrapper: mocks.wrapper },
-    );
+    const { result } = renderHook(() => useCloudAccounts({ limit: 5, offset: 10 }), {
+      wrapper: mocks.wrapper
+    });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.pagination.total).toBe(42);
   });
   it('enters error state on non-200 response', async () => {
-    mocks.addMock(
-      '/api/rhsm/v2/cloud_access_providers/accounts?limit=10&offset=0',
-      {},
-      false,
-    );
-    const { result } = renderHook(
-      () => useCloudAccounts({ limit: 10, offset: 0 }),
-      { wrapper: mocks.wrapper },
-    );
+    mocks.addMock('/api/rhsm/v2/cloud_access_providers/accounts?limit=10&offset=0', {}, false);
+    const { result } = renderHook(() => useCloudAccounts({ limit: 10, offset: 0 }), {
+      wrapper: mocks.wrapper
+    });
     await waitFor(() => expect(result.current.isError).toBe(true));
   });
   it('enters error state on network failure', async () => {
-    global.fetch = jest.fn(() =>
-      Promise.reject(new Error('Network error')),
-    ) as jest.Mock;
-    const { result } = renderHook(
-      () => useCloudAccounts({ limit: 10, offset: 0 }),
-      { wrapper: mocks.wrapper },
-    );
+    global.fetch = jest.fn(() => Promise.reject(new Error('Network error'))) as jest.Mock;
+    const { result } = renderHook(() => useCloudAccounts({ limit: 10, offset: 0 }), {
+      wrapper: mocks.wrapper
+    });
     await waitFor(() => expect(result.current.isError).toBe(true));
   });
   it('starts in loading state', () => {
-    mocks.addMock(
-      '/api/rhsm/v2/cloud_access_providers/accounts?limit=10&offset=0',
-      {},
-      true,
-    );
-    const { result } = renderHook(
-      () => useCloudAccounts({ limit: 10, offset: 0 }),
-      { wrapper: mocks.wrapper },
-    );
+    mocks.addMock('/api/rhsm/v2/cloud_access_providers/accounts?limit=10&offset=0', {}, true);
+    const { result } = renderHook(() => useCloudAccounts({ limit: 10, offset: 0 }), {
+      wrapper: mocks.wrapper
+    });
     expect(result.current.isLoading).toBe(true);
   });
 });

--- a/src/hooks/api/__tests__/useGoldImages.test.ts
+++ b/src/hooks/api/__tests__/useGoldImages.test.ts
@@ -11,19 +11,19 @@ describe('Gold Images hook', () => {
     mocks.addMock(
       '/api/rhsm/v2/cloud_access_providers/gold_images',
       {
-        body: { AWS: { provider: 'AWS', goldImages: [] } },
+        body: { AWS: { provider: 'AWS', goldImages: [] } }
       },
-      true,
+      true
     );
 
     const { result } = renderHook(() => useGoldImages(), {
-      wrapper: mocks.wrapper,
+      wrapper: mocks.wrapper
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data).toStrictEqual({
-      AWS: { provider: 'AWS', goldImages: [] },
+      AWS: { provider: 'AWS', goldImages: [] }
     });
   });
 
@@ -31,7 +31,7 @@ describe('Gold Images hook', () => {
     mocks.addMock('/api/rhsm/v2/cloud_access_providers/gold_images', {}, false);
 
     const { result } = renderHook(() => useGoldImages(), {
-      wrapper: mocks.wrapper,
+      wrapper: mocks.wrapper
     });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));

--- a/src/hooks/api/__tests__/useMarketplacePurchases.test.tsx
+++ b/src/hooks/api/__tests__/useMarketplacePurchases.test.tsx
@@ -4,12 +4,11 @@ import { useMarketplacePurchases } from '../useMarketplacePurchases';
 
 const mocks = new RequestMocks();
 
-const marketplacePurchasesUrl =
-  '/api/rhsm/v2/cloud_access_providers/marketplace_purchases';
+const marketplacePurchasesUrl = '/api/rhsm/v2/cloud_access_providers/marketplace_purchases';
 
 const defaultArgs = {
   limit: 10,
-  offset: 0,
+  offset: 0
 };
 
 const defaultMarketplacePurchasesUrl = `${marketplacePurchasesUrl}?limit=10&offset=0&sort_by=startDate&sort_direction=desc`;
@@ -33,21 +32,21 @@ describe('useMarketplacePurchases', () => {
             marketplaceAccount: '123456789',
             marketplace: 'aws_marketplace',
             startDate: '2026-07-13T00:00:00Z',
-            skus: ['RH02612'],
-          },
+            skus: ['RH02612']
+          }
         ],
         pagination: {
           count: 1,
           limit: 10,
           offset: 0,
-          total: 1,
-        },
+          total: 1
+        }
       },
-      true,
+      true
     );
 
     const { result } = renderHook(() => useMarketplacePurchases(defaultArgs), {
-      wrapper: mocks.wrapper,
+      wrapper: mocks.wrapper
     });
 
     await waitFor(() => {
@@ -55,9 +54,7 @@ describe('useMarketplacePurchases', () => {
     });
 
     expect(result.current.data?.body).toHaveLength(1);
-    expect(result.current.data?.body[0].offeringName).toBe(
-      'Red Hat Enterprise Linux',
-    );
+    expect(result.current.data?.body[0].offeringName).toBe('Red Hat Enterprise Linux');
     expect(result.current.data?.pagination.total).toBe(1);
   });
 
@@ -70,14 +67,14 @@ describe('useMarketplacePurchases', () => {
           count: 0,
           limit: 10,
           offset: 0,
-          total: 0,
-        },
+          total: 0
+        }
       },
-      true,
+      true
     );
 
     const { result } = renderHook(() => useMarketplacePurchases(defaultArgs), {
-      wrapper: mocks.wrapper,
+      wrapper: mocks.wrapper
     });
 
     await waitFor(() => {
@@ -91,7 +88,7 @@ describe('useMarketplacePurchases', () => {
   it('exposes pagination metadata returned by the API', async () => {
     const args = {
       limit: 5,
-      offset: 10,
+      offset: 10
     };
 
     mocks.addMock(
@@ -102,14 +99,14 @@ describe('useMarketplacePurchases', () => {
           count: 5,
           limit: 5,
           offset: 10,
-          total: 42,
-        },
+          total: 42
+        }
       },
-      true,
+      true
     );
 
     const { result } = renderHook(() => useMarketplacePurchases(args), {
-      wrapper: mocks.wrapper,
+      wrapper: mocks.wrapper
     });
 
     await waitFor(() => {
@@ -120,7 +117,7 @@ describe('useMarketplacePurchases', () => {
       count: 5,
       limit: 5,
       offset: 10,
-      total: 42,
+      total: 42
     });
   });
 
@@ -130,26 +127,25 @@ describe('useMarketplacePurchases', () => {
       {
         body: [
           {
-            offeringName:
-              'Red Hat OpenShift Streams for Apache Kafka - Testing Purposes Only',
+            offeringName: 'Red Hat OpenShift Streams for Apache Kafka - Testing Purposes Only',
             marketplaceAccount: '665427542893',
             marketplace: 'aws_marketplace',
             startDate: '2025-05-22T18:39:23.826220243Z',
-            skus: ['MW01882'],
-          },
+            skus: ['MW01882']
+          }
         ],
         pagination: {
           count: 1,
           limit: 10,
           offset: 0,
-          total: 1,
-        },
+          total: 1
+        }
       },
-      true,
+      true
     );
 
     const { result } = renderHook(() => useMarketplacePurchases(defaultArgs), {
-      wrapper: mocks.wrapper,
+      wrapper: mocks.wrapper
     });
 
     await waitFor(() => {
@@ -157,12 +153,11 @@ describe('useMarketplacePurchases', () => {
     });
 
     expect(result.current.data?.body[0]).toStrictEqual({
-      offeringName:
-        'Red Hat OpenShift Streams for Apache Kafka - Testing Purposes Only',
+      offeringName: 'Red Hat OpenShift Streams for Apache Kafka - Testing Purposes Only',
       marketplaceAccount: '665427542893',
       marketplace: 'aws_marketplace',
       startDate: '2025-05-22T18:39:23.826220243Z',
-      skus: ['MW01882'],
+      skus: ['MW01882']
     });
   });
 
@@ -170,7 +165,7 @@ describe('useMarketplacePurchases', () => {
     mocks.addMock(defaultMarketplacePurchasesUrl, {}, false);
 
     const { result } = renderHook(() => useMarketplacePurchases(defaultArgs), {
-      wrapper: mocks.wrapper,
+      wrapper: mocks.wrapper
     });
 
     await waitFor(() => {
@@ -179,12 +174,10 @@ describe('useMarketplacePurchases', () => {
   });
 
   it('enters error state on network failure', async () => {
-    jest
-      .spyOn(global, 'fetch')
-      .mockRejectedValueOnce(new Error('Network error'));
+    jest.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('Network error'));
 
     const { result } = renderHook(() => useMarketplacePurchases(defaultArgs), {
-      wrapper: mocks.wrapper,
+      wrapper: mocks.wrapper
     });
 
     await waitFor(() => {
@@ -196,7 +189,7 @@ describe('useMarketplacePurchases', () => {
     mocks.addMock(defaultMarketplacePurchasesUrl, {}, true);
 
     const { result } = renderHook(() => useMarketplacePurchases(defaultArgs), {
-      wrapper: mocks.wrapper,
+      wrapper: mocks.wrapper
     });
 
     expect(result.current.isLoading).toBe(true);

--- a/src/hooks/api/useCloudAccounts.ts
+++ b/src/hooks/api/useCloudAccounts.ts
@@ -1,9 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { HttpError } from '../../utils/errors';
-import {
-  CloudAccountsResponse,
-  FetchCloudAccountsArgs,
-} from '../../types/cloudAccountsTypes';
+import { CloudAccountsResponse, FetchCloudAccountsArgs } from '../../types/cloudAccountsTypes';
 
 const fetchCloudAccounts = async ({
   limit,
@@ -12,11 +9,11 @@ const fetchCloudAccounts = async ({
   sortDirection,
   providerAccountID,
   shortName,
-  goldImageAccess,
+  goldImageAccess
 }: FetchCloudAccountsArgs): Promise<CloudAccountsResponse> => {
   const params = new URLSearchParams({
     limit: String(limit),
-    offset: String(offset),
+    offset: String(offset)
   });
 
   if (sortField && sortDirection) {
@@ -36,16 +33,10 @@ const fetchCloudAccounts = async ({
     params.set('goldImageAccess', goldImageAccess.join(','));
   }
 
-  const response = await fetch(
-    `/api/rhsm/v2/cloud_access_providers/accounts?${params.toString()}`,
-  );
+  const response = await fetch(`/api/rhsm/v2/cloud_access_providers/accounts?${params.toString()}`);
 
   if (!response.ok) {
-    throw new HttpError(
-      'Something went wrong',
-      response.status,
-      response.statusText,
-    );
+    throw new HttpError('Something went wrong', response.status, response.statusText);
   }
 
   const json = await response.json();
@@ -55,6 +46,6 @@ const fetchCloudAccounts = async ({
 export const useCloudAccounts = (args: FetchCloudAccountsArgs) => {
   return useQuery({
     queryKey: ['cloudAccounts', args],
-    queryFn: () => fetchCloudAccounts(args),
+    queryFn: () => fetchCloudAccounts(args)
   });
 };

--- a/src/hooks/api/useGoldImages.ts
+++ b/src/hooks/api/useGoldImages.ts
@@ -9,7 +9,7 @@ type GoldImage = {
 export enum CloudProviderName {
   AWS = 'AWS',
   GCP = 'Google Compute Engine',
-  AZURE = 'Microsoft Azure',
+  AZURE = 'Microsoft Azure'
 }
 
 type CloudProviderDetail = {
@@ -20,16 +20,10 @@ type CloudProviderDetail = {
 export type GoldImagesResponse = Record<string, CloudProviderDetail>;
 
 const fetchGoldImages: () => Promise<GoldImagesResponse> = async () => {
-  const response = await fetch(
-    '/api/rhsm/v2/cloud_access_providers/gold_images',
-  );
+  const response = await fetch('/api/rhsm/v2/cloud_access_providers/gold_images');
 
   if (!response.ok) {
-    throw new HttpError(
-      `Something went wrong`,
-      response.status,
-      response.statusText,
-    );
+    throw new HttpError(`Something went wrong`, response.status, response.statusText);
   }
 
   return (await response.json()).body as GoldImagesResponse;

--- a/src/hooks/api/useMarketplacePurchases.ts
+++ b/src/hooks/api/useMarketplacePurchases.ts
@@ -26,38 +26,31 @@ export type FetchMarketplacePurchasesArgs = {
 
 const fetchMarketplacePurchases = async ({
   limit,
-  offset,
+  offset
 }: FetchMarketplacePurchasesArgs): Promise<MarketplacePurchasesResponse> => {
   const params = new URLSearchParams({
     limit: String(limit),
-    offset: String(offset),
+    offset: String(offset)
   });
 
   params.set('sort_by', 'startDate');
   params.set('sort_direction', 'desc');
 
   const response = await fetch(
-    `/api/rhsm/v2/cloud_access_providers/marketplace_purchases?${params.toString()}`,
+    `/api/rhsm/v2/cloud_access_providers/marketplace_purchases?${params.toString()}`
   );
 
   if (!response.ok) {
-    throw new HttpError(
-      'Something went wrong',
-      response.status,
-      response.statusText,
-    );
+    throw new HttpError('Something went wrong', response.status, response.statusText);
   }
   const json = await response.json();
   return json as MarketplacePurchasesResponse;
 };
 
-export const useMarketplacePurchases = (
-  args: FetchMarketplacePurchasesArgs,
-  enabled = true,
-) => {
+export const useMarketplacePurchases = (args: FetchMarketplacePurchasesArgs, enabled = true) => {
   return useQuery({
     queryKey: ['marketplacePurchases', args],
     queryFn: () => fetchMarketplacePurchases(args),
-    enabled,
+    enabled
   });
 };

--- a/src/hooks/util/__tests__/useHasRelation.test.tsx
+++ b/src/hooks/util/__tests__/useHasRelation.test.tsx
@@ -6,18 +6,18 @@ import { Relation, useHasRelation } from '../useHasRelation';
 const mockCheck = jest.fn();
 const mockGetUser = jest.fn();
 jest.mock('@project-kessel/react-kessel-access-check', () => ({
-  useAccessCheckContext: jest.fn(() => ({})),
+  useAccessCheckContext: jest.fn(() => ({}))
 }));
 jest.mock('@project-kessel/react-kessel-access-check/core/api-client', () => ({
-  checkSelf: (...args: unknown[]) => mockCheck(...args),
+  checkSelf: (...args: unknown[]) => mockCheck(...args)
 }));
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   __esModule: true,
   default: () => ({
     auth: {
-      getUser: mockGetUser,
-    },
-  }),
+      getUser: mockGetUser
+    }
+  })
 }));
 
 describe('useHasRelation', () => {
@@ -27,15 +27,15 @@ describe('useHasRelation', () => {
     return null;
   };
   const { ComponentWithQueryClient, queryClient } = ManipulatableQueryWrapper(
-    <HookConsumer relation={Relation.CLOUD_ACCESS_VIEW} />,
+    <HookConsumer relation={Relation.CLOUD_ACCESS_VIEW} />
   );
   beforeEach(() => {
     queryClient.clear();
     jest.clearAllMocks();
     mockGetUser.mockResolvedValue({
       identity: {
-        org_id: 'org-id',
-      },
+        org_id: 'org-id'
+      }
     });
     mockCheck.mockResolvedValue({ allowed: 'ALLOWED_TRUE' });
   });
@@ -75,9 +75,9 @@ describe('useHasRelation', () => {
           resource: {
             id: 'redhat/org-id',
             type: 'tenant',
-            reporter: { type: 'rbac' },
-          },
-        },
+            reporter: { type: 'rbac' }
+          }
+        }
       );
     });
   });

--- a/src/hooks/util/__tests__/useQueryParam.test.ts
+++ b/src/hooks/util/__tests__/useQueryParam.test.ts
@@ -1,10 +1,7 @@
 import { atom } from 'jotai';
 import { renderHookWithRouter } from '../../../utils/testing/customRender';
 import { generateQueryParamsForData } from '../useQueryParam';
-import {
-  useQueryParamInformedAtom,
-  useQueryParamInformedState,
-} from '../useQueryParam';
+import { useQueryParamInformedAtom, useQueryParamInformedState } from '../useQueryParam';
 import { useEffect } from 'react';
 import { waitFor } from '@testing-library/react';
 import { __resetQueryParamBatchforTests } from '../useQueryParam';
@@ -27,20 +24,17 @@ jest.mock('react-router-dom', () => ({
 
     const snapshot = new URLSearchParams(mockURLSearchParams.toString());
 
-    type SetSearchParamsArg =
-      | URLSearchParams
-      | ((prev: URLSearchParams) => URLSearchParams);
+    type SetSearchParamsArg = URLSearchParams | ((prev: URLSearchParams) => URLSearchParams);
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const setSearchParams = (next: SetSearchParamsArg, ..._args: unknown[]) => {
-      const resolved =
-        typeof next === 'function' ? next(mockURLSearchParams) : next;
+      const resolved = typeof next === 'function' ? next(mockURLSearchParams) : next;
 
       mockURLSearchParams = new URLSearchParams(resolved.toString());
     };
 
     return [snapshot, setSearchParams] as const;
-  },
+  }
 }));
 
 describe('query param informed hook', () => {
@@ -52,9 +46,7 @@ describe('query param informed hook', () => {
     const customAtom = atom<number>(1);
     mockURLSearchParams = new URLSearchParams({ num: '2' });
 
-    const { result } = renderHookWithRouter(() =>
-      useQueryParamInformedAtom(customAtom, 'num'),
-    );
+    const { result } = renderHookWithRouter(() => useQueryParamInformedAtom(customAtom, 'num'));
 
     expect(result.current[0]).toEqual(2);
   });
@@ -62,9 +54,7 @@ describe('query param informed hook', () => {
   it('initializes state if present', () => {
     mockURLSearchParams = new URLSearchParams({ str: '"test"' });
 
-    const { result } = renderHookWithRouter(() =>
-      useQueryParamInformedState('', 'str'),
-    );
+    const { result } = renderHookWithRouter(() => useQueryParamInformedState('', 'str'));
 
     expect(result.current[0]).toEqual('test');
   });
@@ -72,11 +62,11 @@ describe('query param informed hook', () => {
   it('uses default if no search is present', () => {
     const customAtom = atom<string>('defaultAtom');
     const { result: stateResult } = renderHookWithRouter(() =>
-      useQueryParamInformedState('defaultState', 'str'),
+      useQueryParamInformedState('defaultState', 'str')
     );
 
     const { result: atomResult } = renderHookWithRouter(() =>
-      useQueryParamInformedAtom(customAtom, 'num'),
+      useQueryParamInformedAtom(customAtom, 'num')
     );
 
     expect(stateResult.current[0]).toEqual('defaultState');
@@ -133,10 +123,7 @@ describe('query param informed hook', () => {
 
     const { result } = renderHookWithRouter(() => {
       const [state, setState] = useQueryParamInformedState(1, 'customState');
-      const [atomVal, setAtomVal] = useQueryParamInformedAtom(
-        customAtom,
-        'customAtom',
-      );
+      const [atomVal, setAtomVal] = useQueryParamInformedAtom(customAtom, 'customAtom');
 
       useEffect(() => {
         setState(2);

--- a/src/hooks/util/cloudProviderMaps.ts
+++ b/src/hooks/util/cloudProviderMaps.ts
@@ -1,20 +1,14 @@
-import {
-  CloudProviderDisplayNames,
-  CloudProviderShortname,
-} from '../../types/cloudAccountsTypes';
+import { CloudProviderDisplayNames, CloudProviderShortname } from '../../types/cloudAccountsTypes';
 import { CloudProviderName } from '../api/useGoldImages';
 
-export const shortToFriendly: Record<
-  CloudProviderShortname,
-  CloudProviderName
-> = {
+export const shortToFriendly: Record<CloudProviderShortname, CloudProviderName> = {
   [CloudProviderShortname.AWS]: CloudProviderName.AWS,
   [CloudProviderShortname.GCP]: CloudProviderName.GCP,
-  [CloudProviderShortname.AZURE]: CloudProviderName.AZURE,
+  [CloudProviderShortname.AZURE]: CloudProviderName.AZURE
 };
 
 export const marketplaceToFriendly: Record<string, string> = {
   aws_marketplace: CloudProviderDisplayNames.AWS,
   azure_marketplace: CloudProviderDisplayNames.AZURE,
-  gcp_marketplace: CloudProviderDisplayNames.GCP,
+  gcp_marketplace: CloudProviderDisplayNames.GCP
 };

--- a/src/hooks/util/tables/__tests__/useTableSort.test.ts
+++ b/src/hooks/util/tables/__tests__/useTableSort.test.ts
@@ -8,21 +8,15 @@ import { expectToThrow } from '../../../../utils/testing/expectToThrow';
 describe('Table sort hook', () => {
   it("doesn't sort initially", async () => {
     const initialData = [{ test: 2 }, { test: 1 }, { test: 3 }];
-    const { result } = renderHookWithRouter(() =>
-      useTableSort(initialData, 'data'),
-    );
+    const { result } = renderHookWithRouter(() => useTableSort(initialData, 'data'));
 
-    (await waitFor(() => expect(result.current.sorted))).toStrictEqual(
-      initialData,
-    );
+    (await waitFor(() => expect(result.current.sorted))).toStrictEqual(initialData);
   });
 
   it('can sort numbers', async () => {
     const initialData = [{ test: 2 }, { test: 1 }, { test: 3 }];
     const sortedData = initialData.sort((a, b) => (a.test < b.test ? 1 : 0));
-    const { result } = renderHookWithRouter(() =>
-      useTableSort(initialData, 'data'),
-    );
+    const { result } = renderHookWithRouter(() => useTableSort(initialData, 'data'));
 
     if (result.current.getSortParams(0).onSort == undefined) {
       throw new Error('onSort not defined');
@@ -35,13 +29,11 @@ describe('Table sort hook', () => {
           null as unknown as MouseEvent,
           0,
           SortByDirection.asc,
-          null as unknown as IExtraColumnData,
-        ),
+          null as unknown as IExtraColumnData
+        )
     );
 
-    (await waitFor(() => expect(result.current.sorted))).toStrictEqual(
-      sortedData,
-    );
+    (await waitFor(() => expect(result.current.sorted))).toStrictEqual(sortedData);
   });
 
   it('sorts by default when asked', async () => {
@@ -49,13 +41,11 @@ describe('Table sort hook', () => {
     const sortedData = initialData.sort((a, b) => (a.test < b.test ? 1 : 0));
     const { result } = renderHookWithRouter(() =>
       useTableSort(initialData, 'data', {
-        initialSort: { dir: SortByDirection.asc, index: 0 },
-      }),
+        initialSort: { dir: SortByDirection.asc, index: 0 }
+      })
     );
 
-    (await waitFor(() => expect(result.current.sorted))).toStrictEqual(
-      sortedData,
-    );
+    (await waitFor(() => expect(result.current.sorted))).toStrictEqual(sortedData);
   });
 
   it('can sort strings', async () => {
@@ -63,13 +53,11 @@ describe('Table sort hook', () => {
     const sortedData = initialData.sort((a, b) => a.test.localeCompare(b.test));
     const { result } = renderHookWithRouter(() =>
       useTableSort(initialData, 'data', {
-        initialSort: { dir: SortByDirection.asc, index: 0 },
-      }),
+        initialSort: { dir: SortByDirection.asc, index: 0 }
+      })
     );
 
-    (await waitFor(() => expect(result.current.sorted))).toStrictEqual(
-      sortedData,
-    );
+    (await waitFor(() => expect(result.current.sorted))).toStrictEqual(sortedData);
   });
 
   it('throws error on unsupported types', async () => {
@@ -77,9 +65,9 @@ describe('Table sort hook', () => {
     expectToThrow(async () =>
       renderHookWithRouter(() =>
         useTableSort(initialData, 'data', {
-          initialSort: { dir: SortByDirection.asc, index: 0 },
-        }),
-      ),
+          initialSort: { dir: SortByDirection.asc, index: 0 }
+        })
+      )
     ).rejects.toThrow(/Unsupported type/);
   });
 
@@ -88,9 +76,9 @@ describe('Table sort hook', () => {
     expectToThrow(async () =>
       renderHookWithRouter(() =>
         useTableSort(initialData, 'data', {
-          initialSort: { dir: SortByDirection.asc, index: 0 },
-        }),
-      ),
+          initialSort: { dir: SortByDirection.asc, index: 0 }
+        })
+      )
     ).rejects.toThrow(/Invalid comparison/);
   });
 
@@ -109,9 +97,9 @@ describe('Table sort hook', () => {
           0: 'providerAccountID',
           1: 'shortName',
           2: 'goldImageAccess',
-          3: 'dateAdded',
-        },
-      }),
+          3: 'dateAdded'
+        }
+      })
     );
 
     if (result.current.getSortParams(0).onSort == undefined) {
@@ -125,8 +113,8 @@ describe('Table sort hook', () => {
           null as unknown as MouseEvent,
           3,
           SortByDirection.asc,
-          null as unknown as IExtraColumnData,
-        ),
+          null as unknown as IExtraColumnData
+        )
     );
 
     expect(setSortBy).toHaveBeenCalledWith('dateAdded');

--- a/src/hooks/util/tables/useTableSort.ts
+++ b/src/hooks/util/tables/useTableSort.ts
@@ -18,7 +18,7 @@ type SortFunc<T extends { [s: string]: unknown }> = (
   data: Sortable<T>,
   sortDirection: SortByDirection | undefined,
   sortIndex: number | undefined,
-  rowTranslator: SortableRowTranslator<T>,
+  rowTranslator: SortableRowTranslator<T>
 ) => Sortable<T>;
 
 interface InitialSortOptions {
@@ -45,9 +45,7 @@ interface ApiBasedTableSortResult {
   getSortParams: (index: number) => ThSortType;
 }
 
-function defaultSortableRowTranslator<T extends { [s: string]: unknown }>(
-  o: T,
-) {
+function defaultSortableRowTranslator<T extends { [s: string]: unknown }>(o: T) {
   const rows: (string | number)[] = [];
 
   Object.entries(o).forEach(([k, v]) => {
@@ -55,7 +53,7 @@ function defaultSortableRowTranslator<T extends { [s: string]: unknown }>(
       rows.push(v);
     } else {
       throw new InvalidSortTypeError(
-        `Unsupported type for key ${k}. Got type ${typeof v}, expected string or number`,
+        `Unsupported type for key ${k}. Got type ${typeof v}, expected string or number`
       );
     }
   });
@@ -67,7 +65,7 @@ function defaultSort<T extends { [s: string]: unknown }>(
   data: Sortable<T>,
   sortDirection: SortByDirection | undefined,
   sortIndex: number | undefined,
-  rowTranslator: SortableRowTranslator<T>,
+  rowTranslator: SortableRowTranslator<T>
 ) {
   if (sortIndex === undefined || sortDirection === undefined) {
     return data;
@@ -92,7 +90,7 @@ function defaultSort<T extends { [s: string]: unknown }>(
     }
 
     throw new InvalidSortTypeError(
-      `Invalid comparison between ${typeof aValue} and ${typeof bValue}`,
+      `Invalid comparison between ${typeof aValue} and ${typeof bValue}`
     );
   });
 }
@@ -114,34 +112,33 @@ export function useTableSort<T extends { [s: string]: unknown }>(
   {
     rowTranslator = defaultSortableRowTranslator<T>,
     initialSort = undefined,
-    sortFunc = defaultSort,
-  }: TableSortOptions<T> = {},
+    sortFunc = defaultSort
+  }: TableSortOptions<T> = {}
 ): TableSortResult<T> {
-  const [activeSortIndex, setActiveSortIndex] = useQueryParamInformedState<
-    number | undefined
-  >(initialSort?.index, `${key}ActiveSortIndex`);
-  const [activeSortDirection, setActiveSortDirection] =
-    useQueryParamInformedState<SortByDirection | undefined>(
-      initialSort?.dir,
-      `${key}ActiveSortDir`,
-    );
+  const [activeSortIndex, setActiveSortIndex] = useQueryParamInformedState<number | undefined>(
+    initialSort?.index,
+    `${key}ActiveSortIndex`
+  );
+  const [activeSortDirection, setActiveSortDirection] = useQueryParamInformedState<
+    SortByDirection | undefined
+  >(initialSort?.dir, `${key}ActiveSortDir`);
 
   const getSortParams = (index: number) => ({
     sortBy: {
       index: activeSortIndex,
       direction: activeSortDirection,
-      defaultDirection: SortByDirection.asc,
+      defaultDirection: SortByDirection.asc
     },
     onSort: (_event: MouseEvent, index: number, direction: SortByDirection) => {
       setActiveSortIndex(index);
       setActiveSortDirection(direction);
     },
-    columnIndex: index,
+    columnIndex: index
   });
 
   return {
     sorted: sortFunc(data, activeSortDirection, activeSortIndex, rowTranslator),
-    getSortParams,
+    getSortParams
   };
 }
 
@@ -167,22 +164,19 @@ export function useApiBasedTableSort(
     sortDir,
     setSortBy,
     setSortDir,
-    lookup,
-  }: ApiBasedTableSortOptions,
+    lookup
+  }: ApiBasedTableSortOptions
 ): ApiBasedTableSortResult {
-  const [activeSortIndex, setActiveSortIndex] = useQueryParamInformedState<
-    number | undefined
-  >(initialSort?.index, `${key}ActiveSortIndex`);
-  const [activeSortDirection, setActiveSortDirection] =
-    useQueryParamInformedState<SortByDirection | undefined>(
-      initialSort?.dir,
-      `${key}ActiveSortDir`,
-    );
+  const [activeSortIndex, setActiveSortIndex] = useQueryParamInformedState<number | undefined>(
+    initialSort?.index,
+    `${key}ActiveSortIndex`
+  );
+  const [activeSortDirection, setActiveSortDirection] = useQueryParamInformedState<
+    SortByDirection | undefined
+  >(initialSort?.dir, `${key}ActiveSortDir`);
 
   useEffect(() => {
-    const i = Object.keys(lookup).find(
-      (key) => lookup[parseInt(key)] == sortBy,
-    );
+    const i = Object.keys(lookup).find((key) => lookup[parseInt(key)] == sortBy);
     setActiveSortIndex(i ? parseInt(i) : undefined);
     setActiveSortDirection(sortDir);
   }, [sortBy, sortDir]);
@@ -191,16 +185,16 @@ export function useApiBasedTableSort(
     sortBy: {
       index: activeSortIndex,
       direction: activeSortDirection,
-      defaultDirection: SortByDirection.asc,
+      defaultDirection: SortByDirection.asc
     },
     onSort: (_event: MouseEvent, index: number, direction: SortByDirection) => {
       setSortBy(lookup[index]);
       setSortDir(direction);
     },
-    columnIndex: index,
+    columnIndex: index
   });
 
   return {
-    getSortParams,
+    getSortParams
   };
 }

--- a/src/hooks/util/useHasRelation.ts
+++ b/src/hooks/util/useHasRelation.ts
@@ -7,7 +7,7 @@ const QUERY_STALE_TIME = 5 * 60 * 1000;
 
 export enum Relation {
   CLOUD_ACCESS_VIEW = 'subscriptions_cloud_access_view',
-  CLOUD_ACCESS_EDIT = 'subscriptions_cloud_access_edit',
+  CLOUD_ACCESS_EDIT = 'subscriptions_cloud_access_edit'
 }
 
 interface HasRelationResult {
@@ -35,17 +35,17 @@ export const useHasRelation = (relation: Relation): HasRelationResult => {
             resource: {
               id: `redhat/${user.identity.org_id}`,
               type: 'tenant',
-              reporter: { type: 'rbac' },
-            },
+              reporter: { type: 'rbac' }
+            }
           })
         ).allowed === 'ALLOWED_TRUE'
       );
     },
-    staleTime: QUERY_STALE_TIME,
+    staleTime: QUERY_STALE_TIME
   });
 
   return {
     has: !!has,
-    isLoading: accessCheckIsLoading,
+    isLoading: accessCheckIsLoading
   };
 };

--- a/src/hooks/util/useQueryParam.ts
+++ b/src/hooks/util/useQueryParam.ts
@@ -13,7 +13,7 @@ export function __resetQueryParamBatchforTests() {
 function updateQueryParamsTogether(
   currentSearch: string,
   applyUpdate: (p: URLSearchParams) => void,
-  commitSearchParams: (p: URLSearchParams) => void,
+  commitSearchParams: (p: URLSearchParams) => void
 ) {
   const base = nextParams
     ? new URLSearchParams(nextParams.toString())
@@ -49,31 +49,25 @@ function useInitializeFromQueryParam<T>(key: string, setter: (v: T) => void) {
   }, [init, key, setter]);
 }
 
-export function generateQueryParamsForData<T>(
-  data: T,
-  key: string,
-): URLSearchParams {
+export function generateQueryParamsForData<T>(data: T, key: string): URLSearchParams {
   const params = new URLSearchParams();
   params.set(key, JSON.stringify(data));
   return params;
 }
 
-function useUpdateQueryParams<T>(
-  key: string,
-  setter: (v: T) => void,
-): (v: T) => void {
+function useUpdateQueryParams<T>(key: string, setter: (v: T) => void): (v: T) => void {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const commit = useCallback(
     (p: URLSearchParams) => setSearchParams(p, { replace: true }),
-    [setSearchParams],
+    [setSearchParams]
   );
 
   return (v: T) => {
     updateQueryParamsTogether(
       searchParams.toString(),
       (p) => p.set(key, JSON.stringify(v)),
-      commit,
+      commit
     );
 
     setter(v);
@@ -82,7 +76,7 @@ function useUpdateQueryParams<T>(
 
 export function useQueryParamInformedAtom<T>(
   atom: PrimitiveAtom<T>,
-  key: string,
+  key: string
 ): [Awaited<T>, (v: T) => void] {
   const [atomValue, setAtom] = useAtom(atom);
 
@@ -92,10 +86,7 @@ export function useQueryParamInformedAtom<T>(
   return [atomValue, queryParamWrappedSetter];
 }
 
-export function useQueryParamInformedState<T>(
-  init: T,
-  key: string,
-): [T, (v: T) => void] {
+export function useQueryParamInformedState<T>(init: T, key: string): [T, (v: T) => void] {
   const [state, setState] = useState(init);
 
   useInitializeFromQueryParam(key, setState);

--- a/src/state/cloudAccounts.ts
+++ b/src/state/cloudAccounts.ts
@@ -15,6 +15,9 @@ export const CloudAccountsPaginationData = atom<PaginationData>({
 });
 
 export type CloudAccountsSortField =
-  'providerAccountID' | 'provider' | 'goldImageAccess' | 'dateAdded';
+  | 'providerAccountID'
+  | 'provider'
+  | 'goldImageAccess'
+  | 'dateAdded';
 
 export const cloudAccountsFilterCategoryData = atom<'ID' | 'Provider' | 'Status'>('ID');

--- a/src/state/cloudAccounts.ts
+++ b/src/state/cloudAccounts.ts
@@ -11,15 +11,10 @@ export const cloudAccountIDFilterData = atom<string>('');
 export const CloudAccountsPaginationData = atom<PaginationData>({
   page: 1,
   perPage: 10,
-  itemCount: 0,
+  itemCount: 0
 });
 
 export type CloudAccountsSortField =
-  | 'providerAccountID'
-  | 'provider'
-  | 'goldImageAccess'
-  | 'dateAdded';
+  'providerAccountID' | 'provider' | 'goldImageAccess' | 'dateAdded';
 
-export const cloudAccountsFilterCategoryData = atom<
-  'ID' | 'Provider' | 'Status'
->('ID');
+export const cloudAccountsFilterCategoryData = atom<'ID' | 'Provider' | 'Status'>('ID');

--- a/src/state/goldImages.ts
+++ b/src/state/goldImages.ts
@@ -5,7 +5,7 @@ import { PaginationData } from '../types/pagination';
 export const goldImagePaginationData = atom<PaginationData>({
   page: 1,
   perPage: 10,
-  itemCount: 0,
+  itemCount: 0
 });
 
 export const cloudProviderFilterData = atom<CloudProviderName[]>([]);

--- a/src/state/marketplacePurchases.ts
+++ b/src/state/marketplacePurchases.ts
@@ -4,5 +4,5 @@ import { PaginationData } from '../types/pagination';
 export const MarketplacePurchasesPaginationData = atom<PaginationData>({
   page: 1,
   perPage: 10,
-  itemCount: 0,
+  itemCount: 0
 });

--- a/src/types/cloudAccountsTypes.ts
+++ b/src/types/cloudAccountsTypes.ts
@@ -3,19 +3,19 @@ import { SortByDirection } from '@patternfly/react-table';
 export enum CloudProviderShortname {
   AWS = 'AWS',
   GCP = 'GCE',
-  AZURE = 'MSAZ',
+  AZURE = 'MSAZ'
 }
 
 export enum CloudProviderDisplayNames {
   AWS = 'AWS',
   GCP = 'Google Compute Engine',
-  AZURE = 'Microsoft Azure',
+  AZURE = 'Microsoft Azure'
 }
 
 export const ProviderLabelMap: Record<string, string> = {
   [CloudProviderShortname.AWS]: CloudProviderDisplayNames.AWS,
   [CloudProviderShortname.GCP]: CloudProviderDisplayNames.GCP,
-  [CloudProviderShortname.AZURE]: CloudProviderDisplayNames.AZURE,
+  [CloudProviderShortname.AZURE]: CloudProviderDisplayNames.AZURE
 };
 
 export type CloudAccount = {

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -20,11 +20,7 @@ describe('HttpError', () => {
   it('handles different HTTP status codes', () => {
     const error401 = new HttpError('Unauthorized', 401, 'Unauthorized');
     const error403 = new HttpError('Forbidden', 403, 'Forbidden');
-    const error500 = new HttpError(
-      'Server error',
-      500,
-      'Internal Server Error',
-    );
+    const error500 = new HttpError('Server error', 500, 'Internal Server Error');
 
     expect(error401.status).toBe(401);
     expect(error403.status).toBe(403);
@@ -44,7 +40,7 @@ describe('hasPaginationError', () => {
     const pagination: PaginationData = {
       page: 1,
       perPage: 10,
-      itemCount: 25,
+      itemCount: 25
     };
 
     expect(hasPaginationError(pagination)).toBe(false);
@@ -54,7 +50,7 @@ describe('hasPaginationError', () => {
     const pagination: PaginationData = {
       page: 2,
       perPage: 10,
-      itemCount: 25,
+      itemCount: 25
     };
 
     expect(hasPaginationError(pagination)).toBe(false);
@@ -64,7 +60,7 @@ describe('hasPaginationError', () => {
     const pagination: PaginationData = {
       page: 3,
       perPage: 10,
-      itemCount: 25,
+      itemCount: 25
     };
 
     expect(hasPaginationError(pagination)).toBe(false);
@@ -74,7 +70,7 @@ describe('hasPaginationError', () => {
     const pagination: PaginationData = {
       page: 5,
       perPage: 10,
-      itemCount: 25,
+      itemCount: 25
     };
 
     expect(hasPaginationError(pagination)).toBe(true);
@@ -84,7 +80,7 @@ describe('hasPaginationError', () => {
     const pagination: PaginationData = {
       page: 100,
       perPage: 10,
-      itemCount: 5,
+      itemCount: 5
     };
 
     expect(hasPaginationError(pagination)).toBe(true);
@@ -94,7 +90,7 @@ describe('hasPaginationError', () => {
     const pagination: PaginationData = {
       page: 3,
       perPage: 10,
-      itemCount: 20,
+      itemCount: 20
     };
 
     expect(hasPaginationError(pagination)).toBe(true);
@@ -104,7 +100,7 @@ describe('hasPaginationError', () => {
     const pagination: PaginationData = {
       page: 2,
       perPage: 10,
-      itemCount: 0,
+      itemCount: 0
     };
 
     expect(hasPaginationError(pagination)).toBe(true);
@@ -114,7 +110,7 @@ describe('hasPaginationError', () => {
     const pagination: PaginationData = {
       page: 1,
       perPage: 10,
-      itemCount: 0,
+      itemCount: 0
     };
 
     expect(hasPaginationError(pagination)).toBe(false);
@@ -124,12 +120,12 @@ describe('hasPaginationError', () => {
     const pagination20: PaginationData = {
       page: 2,
       perPage: 20,
-      itemCount: 25,
+      itemCount: 25
     };
     const pagination5: PaginationData = {
       page: 7,
       perPage: 5,
-      itemCount: 25,
+      itemCount: 25
     };
 
     expect(hasPaginationError(pagination20)).toBe(false);
@@ -140,7 +136,7 @@ describe('hasPaginationError', () => {
     const pagination: PaginationData = {
       page: 1,
       perPage: 10,
-      itemCount: 1,
+      itemCount: 1
     };
 
     expect(hasPaginationError(pagination)).toBe(false);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -11,10 +11,7 @@ class HttpError extends Error {
 }
 
 const hasPaginationError = (pagination: PaginationData) => {
-  return (
-    pagination.page != 1 &&
-    pagination.itemCount <= (pagination.page - 1) * pagination.perPage
-  );
+  return pagination.page != 1 && pagination.itemCount <= (pagination.page - 1) * pagination.perPage;
 };
 
 export { HttpError, hasPaginationError };

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -5,5 +5,5 @@ export enum Paths {
   CloudAccounts = 'cloud-accounts',
   MarketplacePurchases = 'marketplace-purchases',
   Catch = '*',
-  Root = '/',
+  Root = '/'
 }

--- a/src/utils/testing/customRender.tsx
+++ b/src/utils/testing/customRender.tsx
@@ -6,15 +6,13 @@ import {
   RenderOptions,
   queries,
   render,
-  renderHook,
+  renderHook
 } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 
 const RouterProvider = ({ children }: { children: React.ReactNode }) => {
   return (
-    <BrowserRouter
-      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
-    >
+    <BrowserRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
       {children}
     </BrowserRouter>
   );
@@ -23,10 +21,7 @@ const RouterProvider = ({ children }: { children: React.ReactNode }) => {
 /**
  * Custom render function that wraps every component in a Router
  */
-const renderWithRouter = (
-  ui: ReactElement,
-  options?: Omit<RenderOptions, 'wrapper'>,
-) => {
+const renderWithRouter = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) => {
   return render(ui, { wrapper: RouterProvider, ...options });
 };
 
@@ -38,10 +33,10 @@ function renderHookWithRouter<
   Props,
   Q extends Queries = typeof queries,
   Container extends Element | DocumentFragment = HTMLElement,
-  BaseElement extends Element | DocumentFragment = Container,
+  BaseElement extends Element | DocumentFragment = Container
 >(
   render: (initialProps: Props) => Result,
-  options?: RenderHookOptions<Props, Q, Container, BaseElement>,
+  options?: RenderHookOptions<Props, Q, Container, BaseElement>
 ): RenderHookResult<Result, Props> {
   const ProvidedWrapper = options?.wrapper;
   const CustomWrapper = ProvidedWrapper
@@ -53,7 +48,7 @@ function renderHookWithRouter<
     : RouterProvider;
   return renderHook(render, {
     ...options,
-    wrapper: CustomWrapper,
+    wrapper: CustomWrapper
   });
 }
 


### PR DESCRIPTION
This adds a basic claude.md file, and also updates the linting/formatting rules for this app to match our others. Those are also applied in this commit, so there are a large number of formatting changes.

## Summary by Sourcery

Add a contributor-facing CLAUDE.md guide and reformat existing TypeScript/React code and tests to align with the shared linting and formatting conventions across the project.

Enhancements:
- Align Cloud Inventory React components, hooks, and tests with the updated linting and Prettier/ESLint style rules, including import ordering, trailing commas, and JSX formatting.
- Improve consistency of pagination, filtering, routing, and query-param utilities without changing their behavior, clarifying URL-synced state patterns and shared pagination error handling.

Build:
- Update Prettier configuration to enforce the new code style consistently across the codebase.

Documentation:
- Introduce CLAUDE.md documenting project architecture, conventions, testing strategy, and local development workflows for AI assistants and contributors.

Tests:
- Refactor existing Jest and React Testing Library tests for Cloud Accounts, Gold Images, Marketplace Purchases, routing, and shared utilities to match the new formatting and test helper usage without altering coverage or behavior.